### PR TITLE
securityfix: Filter media files by user permission in chooser panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- TBC
+- Added filtering of media files by user permission in chooser panel ([#25](https://github.com/torchbox/wagtailmedia/pull/25)). Thanks to [@snj](https://github.com/snj)
 
 ## [0.5.0] - 2020-02-20
 

--- a/wagtailmedia/views/chooser.py
+++ b/wagtailmedia/views/chooser.py
@@ -39,9 +39,9 @@ def get_media_json(media):
 
 
 def chooser(request):
-    Media = get_media_model()
-
-    media_files = Media.objects.all()
+    media_files = permission_policy.instances_user_has_any_permission_for(
+        request.user, ['change', 'delete']
+    )
 
     # allow hooks to modify the queryset
     for hook in hooks.get_hooks('construct_media_chooser_queryset'):


### PR DESCRIPTION
I fixed the problem that users those who don't have permission can see the media files.