### PR TITLE
Add issue template from Wagtail

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+Found a bug? Please fill out the sections below. 👍
+
+### Issue Summary
+
+A summary of the issue.
+
+
+### Steps to Reproduce
+
+1. (for example) Start a new project with `wagtail start myproject`
+2. Integrate `wagtailmedia` as follows…
+3. ...
+
+Any other relevant information. For example, why do you consider this a bug and what did you expect to happen instead?
+
+### Technical details
+
+* Python version: Run `python --version`.
+* Django version: Look in your requirements.txt, or run `pip show django | grep Version`.
+* Wagtail version: Hover over the Wagtail bird in the admin, or run `pip show wagtail | grep Version:`.
+* `wagtailmedia` version: Look in your requirements.txt, or run `pip show wagtailmedia | grep Version`.
+* Browser version: You can use http://www.whatsmybrowser.org/ to find this out.


### PR DESCRIPTION
This feels like it would be useful on any Wagtail-related project that has a non-trivial API like this, and support for a wide range of versions. I'll merge this right away but feel free to make follow-up PRs with any relevant changes. In particular it might be good to use separate templates for bugs, support, and feature requests.