### PR TITLE
Document media field name clash. Fix #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,42 @@ WAGTAILMEDIA_MEDIA_MODEL = 'mymedia.CustomMedia'
 
 ## How to use
 
+### As a regular Django field
+
+You can use `Media` as a regular Django field. Here’s an example:
+
+```python
+from __future__ import unicode_literals
+
+from django.db import models
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.fields import RichTextField
+from wagtail.wagtailadmin.edit_handlers import FieldPanel
+
+from wagtailmedia.edit_handlers import MediaChooserPanel
+
+
+class BlogPageWithMedia(Page):
+    author = models.CharField(max_length=255)
+    date = models.DateField("Post date")
+    body = RichTextField(blank=False)
+    media = models.ForeignKey(
+        'wagtailmedia.Media',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='+'
+    )
+
+    content_panels = Page.content_panels + [
+        FieldPanel('author'),
+        FieldPanel('date'),
+        FieldPanel('body'),
+        MediaChooserPanel('media'),
+    ]
+```
+
 ### In StreamField
 
 You can use `Media` in StreamField. To do this, you need
@@ -123,44 +159,6 @@ class BlogPage(Page):
         FieldPanel('author'),
         FieldPanel('date'),
         StreamFieldPanel('body'),
-    ]
-```
-
-### As a regular Django field
-
-Also, you can use `Media` as a regular Django field.
-
-Example
-
-```python
-from __future__ import unicode_literals
-
-from django.db import models
-
-from wagtail.wagtailcore.models import Page
-from wagtail.wagtailcore.fields import RichTextField
-from wagtail.wagtailadmin.edit_handlers import FieldPanel
-
-from wagtailmedia.edit_handlers import MediaChooserPanel
-
-
-class BlogPageWithMedia(Page):
-    author = models.CharField(max_length=255)
-    date = models.DateField("Post date")
-    body = RichTextField(blank=False)
-    media = models.ForeignKey(
-        'wagtailmedia.Media',
-        null=True,
-        blank=True,
-        on_delete=models.SET_NULL,
-        related_name='+'
-    )
-
-    content_panels = Page.content_panels + [
-        FieldPanel('author'),
-        FieldPanel('date'),
-        FieldPanel('body'),
-        MediaChooserPanel('media'),
     ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ but for audio and video files.
 
 Install using pip:
 
-```
+```sh
 pip install wagtailmedia
 ```
-
 
 ### Settings
 
@@ -27,7 +26,6 @@ INSTALLED_APPS = [
     # ...
 ]
 ```
-
 
 ### URL configuration
 
@@ -50,7 +48,6 @@ and [Deploying static files](https://docs.djangoproject.com/en/stable/howto/stat
 
 With this configuration in place, you are ready to run `./manage.py migrate` to create the database tables used by wagtailmedia.
 
-
 ### Custom `Media` model
 
 The `Media` model can be customised. To do this, you need
@@ -61,7 +58,6 @@ Then set the `WAGTAILMEDIA_MEDIA_MODEL` setting to point to it:
 ```python
 WAGTAILMEDIA_MEDIA_MODEL = 'mymedia.CustomMedia'
 ```
-
 
 ## How to use
 
@@ -168,18 +164,27 @@ class BlogPageWithMedia(Page):
     ]
 ```
 
+## Contributing
 
-## How to run tests
+### Install
 
-To run tests you need to clone this repository:
+To make changes to this project, first clone this repository:
 
-    git clone https://github.com/torchbox/wagtailmedia.git
-    cd wagtailmedia
+```sh
+git clone git@github.com:torchbox/wagtailmedia.git
+cd wagtailmedia
+```
 
 With your preferred virtualenv activated, install testing dependencies:
 
-    pip install -e .[testing] -U
+```sh
+pip install -e .[testing] -U
+```
+
+### How to run tests
 
 Now you can run tests as shown below:
 
-    python runtests.py
+```sh
+python runtests.py
+```

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ class BlogPageWithMedia(Page):
     author = models.CharField(max_length=255)
     date = models.DateField("Post date")
     body = RichTextField(blank=False)
-    media = models.ForeignKey(
+    featured_media = models.ForeignKey(
         'wagtailmedia.Media',
         null=True,
         blank=True,
@@ -93,9 +93,13 @@ class BlogPageWithMedia(Page):
         FieldPanel('author'),
         FieldPanel('date'),
         FieldPanel('body'),
-        MediaChooserPanel('media'),
+        MediaChooserPanel('featured_media'),
     ]
 ```
+
+#### Name clash with Wagtail
+
+Do not name the field `media`. When rendering the admin UI, Wagtail uses a `media` property for its fields’ CSS & JS assets loading. Using `media` as a field name breaks the admin UI ([#54](https://github.com/torchbox/wagtailmedia/issues/54)).
 
 ### In StreamField
 


### PR DESCRIPTION
Fixes #54. This moves the docs around a bit, and adds a note about potential name clashes with Wagtail.