### PR TITLE
Allow hooks to modify chooser queryset

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ Then set the `WAGTAILMEDIA_MEDIA_MODEL` setting to point to it:
 WAGTAILMEDIA_MEDIA_MODEL = 'mymedia.CustomMedia'
 ```
 
+### Hooks
+
+#### `construct_media_chooser_queryset`
+
+Called when rendering the media chooser view, to allow the media listing QuerySet to be customised.
+The callable passed into the hook will receive the current media QuerySet and the request object, and must return a Media QuerySet (either the original one, or a new one).
+
+```python
+from wagtail.core import hooks
+
+@hooks.register('construct_media_chooser_queryset')
+def show_my_uploaded_media_only(media, request):
+    # Only show uploaded media
+    media = media.filter(uploaded_by_user=request.user)
+
+    return media
+```
+
 ## How to use
 
 ### As a regular Django field

--- a/wagtailmedia/views/chooser.py
+++ b/wagtailmedia/views/chooser.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.utils import PermissionPolicyChecker
+from wagtail.core import hooks
 from wagtail.core.models import Collection
 from wagtail.utils.pagination import paginate
 
@@ -34,13 +35,15 @@ def get_media_json(media):
 def chooser(request):
     Media = get_media_model()
 
-    media_files = []
+    media_files = Media.objects.all()
+
+    # allow hooks to modify the queryset
+    for hook in hooks.get_hooks('construct_media_chooser_queryset'):
+        media_files = hook(media_files, request)
 
     q = None
     is_searching = False
     if 'q' in request.GET or 'p' in request.GET or 'collection_id' in request.GET:
-        media_files = Media.objects.all()
-
         collection_id = request.GET.get('collection_id')
         if collection_id:
             media_files = media_files.filter(collection=collection_id)
@@ -70,7 +73,7 @@ def chooser(request):
         if len(collections) < 2:
             collections = None
 
-        media_files = Media.objects.order_by('-created_at')
+        media_files = media_files.order_by('-created_at')
         paginator, media_files = paginate(request, media_files, per_page=10)
 
     return render_modal_workflow(request, 'wagtailmedia/chooser/chooser.html', None, {


### PR DESCRIPTION
It just implements the same hook as `wagtail.documents` with its tests and documentation.