### PR TITLE
Wagtail 2.7 compatibility – Removing dependency on deprecated `wagtail.utils.pagination`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ sudo: false
 
 matrix:
   include:
+   - env: TOXENV=py37-dj22-wag27
+     python: 3.7
+   - env: TOXENV=py37-dj22-wag26
+     python: 3.7
    - env: TOXENV=py37-dj22-wag25
      python: 3.7
    - env: TOXENV=py36-dj21-wag24

--- a/runtests.py
+++ b/runtests.py
@@ -6,6 +6,7 @@ import sys
 import warnings
 
 from django.core.management import execute_from_command_line
+from wagtail.utils.deprecation import RemovedInWagtail27Warning
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtailmedia.tests.settings'
 
@@ -19,7 +20,13 @@ def runtests():
     args = sys.argv[1:]
     argv = sys.argv[:1] + ['test'] + args
     try:
-        execute_from_command_line(argv)
+        # adding an assert to catch RemovedInWagtail27Warning warnings
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            execute_from_command_line(argv)
+            for warning in w:
+                assert not isinstance(warning.message, RemovedInWagtail27Warning), \
+                    'These tests raised a RemovedInWagtail27Warning.'
     finally:
         from wagtailmedia.tests.settings import STATIC_ROOT, MEDIA_ROOT
         shutil.rmtree(STATIC_ROOT, ignore_errors=True)

--- a/runtests.py
+++ b/runtests.py
@@ -6,7 +6,12 @@ import sys
 import warnings
 
 from django.core.management import execute_from_command_line
-from wagtail.utils.deprecation import RemovedInWagtail27Warning
+
+try:
+    from wagtail.utils.deprecation import RemovedInWagtail27Warning
+except ImportError:
+    class RemovedInWagtail27Warning(Warning):
+        pass
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtailmedia.tests.settings'
 
@@ -21,12 +26,8 @@ def runtests():
     argv = sys.argv[:1] + ['test'] + args
     try:
         # adding an assert to catch RemovedInWagtail27Warning warnings
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            execute_from_command_line(argv)
-            for warning in w:
-                assert not isinstance(warning.message, RemovedInWagtail27Warning), \
-                    f'These tests raised a RemovedInWagtail27Warning. {warning.message}'
+        warnings.filterwarnings('error', category=RemovedInWagtail27Warning)
+        execute_from_command_line(argv)
     finally:
         from wagtailmedia.tests.settings import STATIC_ROOT, MEDIA_ROOT
         shutil.rmtree(STATIC_ROOT, ignore_errors=True)

--- a/runtests.py
+++ b/runtests.py
@@ -26,7 +26,7 @@ def runtests():
             execute_from_command_line(argv)
             for warning in w:
                 assert not isinstance(warning.message, RemovedInWagtail27Warning), \
-                    'These tests raised a RemovedInWagtail27Warning.'
+                    f'These tests raised a RemovedInWagtail27Warning. {warning.message}'
     finally:
         from wagtailmedia.tests.settings import STATIC_ROOT, MEDIA_ROOT
         shutil.rmtree(STATIC_ROOT, ignore_errors=True)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{35,36,37}-dj{20,21,22}-wag{22,23,24,25},
+envlist = py{35,36,37}-dj{20,21,22}-wag{22,23,24,25,26,27},
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -23,3 +23,5 @@ deps =
     wag23: wagtail>=2.3,<2.4
     wag24: wagtail>=2.4,<2.5
     wag25: wagtail>=2.5,<2.6
+    wag26: wagtail>=2.6,<2.7
+    wag27: wagtail>=2.7,<2.8

--- a/wagtailmedia/templates/wagtailmedia/chooser/results.html
+++ b/wagtailmedia/templates/wagtailmedia/chooser/results.html
@@ -14,7 +14,7 @@
 
     {% include "wagtailmedia/media/list.html" with choosing=1 %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=media_files is_ajax=1 %}
+    {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=media_files is_ajax=1 %}
 {% else %}
     <p>{% blocktrans %}Sorry, no media files match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
 {% endif %}

--- a/wagtailmedia/templates/wagtailmedia/chooser/results.html
+++ b/wagtailmedia/templates/wagtailmedia/chooser/results.html
@@ -14,7 +14,7 @@
 
     {% include "wagtailmedia/media/list.html" with choosing=1 %}
 
-    {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=media_files is_ajax=1 %}
+    {% include pagination_template with items=media_files is_ajax=1 %}
 {% else %}
     <p>{% blocktrans %}Sorry, no media files match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
 {% endif %}

--- a/wagtailmedia/utils.py
+++ b/wagtailmedia/utils.py
@@ -1,9 +1,14 @@
-from django.core.paginator import Paginator
+from wagtail import VERSION as WAGTAIL_VERSION
 
-DEFAULT_PAGE_KEY = 'p'
+if WAGTAIL_VERSION < (2, 5):
+    from wagtail.utils.pagination import paginate
+else:
+    from django.core.paginator import Paginator
+
+    DEFAULT_PAGE_KEY = 'p'
 
 
-def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20):
-    paginator = Paginator(items, per_page)
-    page = paginator.get_page(request.GET.get(page_key))
-    return paginator, page
+    def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20):
+        paginator = Paginator(items, per_page)
+        page = paginator.get_page(request.GET.get(page_key))
+        return paginator, page

--- a/wagtailmedia/utils.py
+++ b/wagtailmedia/utils.py
@@ -1,0 +1,9 @@
+from django.core.paginator import Paginator
+
+DEFAULT_PAGE_KEY = 'p'
+
+
+def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20):
+    paginator = Paginator(items, per_page)
+    page = paginator.get_page(request.GET.get(page_key))
+    return paginator, page

--- a/wagtailmedia/utils.py
+++ b/wagtailmedia/utils.py
@@ -7,7 +7,6 @@ else:
 
     DEFAULT_PAGE_KEY = 'p'
 
-
     def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20):
         paginator = Paginator(items, per_page)
         page = paginator.get_page(request.GET.get(page_key))

--- a/wagtailmedia/views/chooser.py
+++ b/wagtailmedia/views/chooser.py
@@ -12,8 +12,10 @@ from wagtailmedia.utils import paginate
 
 if WAGTAIL_VERSION < (2, 5):
     from wagtail.admin.forms import SearchForm
+    pagination_template = "wagtailadmin/shared/pagination_nav.html"
 else:
     from wagtail.admin.forms.search import SearchForm
+    pagination_template = "wagtailadmin/shared/ajax_pagination_nav.html"
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 
@@ -62,6 +64,7 @@ def chooser(request):
             'media_files': media_files,
             'query_string': q,
             'is_searching': is_searching,
+            'pagination_template': pagination_template,
         })
     else:
         searchform = SearchForm()

--- a/wagtailmedia/views/chooser.py
+++ b/wagtailmedia/views/chooser.py
@@ -5,10 +5,10 @@ from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.utils import PermissionPolicyChecker
 from wagtail.core.models import Collection
-from wagtail.utils.pagination import paginate
 
 from wagtailmedia.models import get_media_model
 from wagtailmedia.permissions import permission_policy
+from wagtailmedia.utils import paginate
 
 if WAGTAIL_VERSION < (2, 5):
     from wagtail.admin.forms import SearchForm

--- a/wagtailmedia/views/media.py
+++ b/wagtailmedia/views/media.py
@@ -10,11 +10,11 @@ from wagtail.admin import messages
 from wagtail.admin.utils import PermissionPolicyChecker, permission_denied, popular_tags_for_model
 from wagtail.core.models import Collection
 from wagtail.search.backends import get_search_backends
-from wagtail.utils.pagination import paginate
 
 from wagtailmedia.forms import get_media_form
 from wagtailmedia.models import get_media_model
 from wagtailmedia.permissions import permission_policy
+from wagtailmedia.utils import paginate
 
 if WAGTAIL_VERSION < (2, 5):
     from wagtail.admin.forms import SearchForm


### PR DESCRIPTION
This Pull Request is a start to fix issue #62 

Right now, it's a test case that throws an error if the `RemovedInWagtail27Warning` warning occurs when the test suite is run. I'm not sure if there's a better way to handle that test, but I know this works.

Since there are two places in the code that calls the pagination utility (`views/chooser.py` and `views/media.py`), I am considering creating a `utils.py` with an implementation of the Django Paginator.