### PR TITLE
simplify type checking for easy templating - None isn't useful here

### DIFF
--- a/wagtailmedia/models.py
+++ b/wagtailmedia/models.py
@@ -85,7 +85,7 @@ class AbstractMedia(CollectionMember, index.Indexed, models.Model):
     def sources(self):
         return [{
             'src': self.url,
-            'type': mimetypes.guess_type(self.filename)[0],
+            'type': mimetypes.guess_type(self.filename)[0] or 'application/octet-stream',
         }]
 
     def get_usage(self):

--- a/wagtailmedia/tests/test_models.py
+++ b/wagtailmedia/tests/test_models.py
@@ -77,5 +77,5 @@ class TestAbstractMediaInterfaceModel(TestCase):
         media.file = File(fake_file)
         self.assertEqual(media.sources, [{
             'src': '/media/movie',
-            'type': None,
+            'type': 'application/octet-stream',
         }])


### PR DESCRIPTION
'application/octet-stream' is the equivalent of None for mimetypes in
the correct type (string)

Fixes #76 