### PR TITLE
Fix Django 3 compability issue

### DIFF
--- a/wagtailmedia/models.py
+++ b/wagtailmedia/models.py
@@ -29,7 +29,8 @@ else:
 try:
     from django.utils.encoding import python_2_unicode_compatible
 except ImportError:
-    python_2_unicode_compatible = lambda x: x
+    def python_2_unicode_compatible(x):
+        return x
 
 
 class MediaQuerySet(SearchableQuerySetMixin, models.QuerySet):

--- a/wagtailmedia/models.py
+++ b/wagtailmedia/models.py
@@ -10,7 +10,6 @@ from django.db.models.signals import pre_delete
 from django.dispatch import Signal
 from django.dispatch.dispatcher import receiver
 from django.urls import reverse
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from taggit.managers import TaggableManager
@@ -23,6 +22,14 @@ if WAGTAIL_VERSION < (2, 9):
     from wagtail.admin.utils import get_object_usage
 else:
     from wagtail.admin.models import get_object_usage
+
+
+# Python 2.x compability apis are removed from Django 3
+# https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    python_2_unicode_compatible = lambda x: x
 
 
 class MediaQuerySet(SearchableQuerySetMixin, models.QuerySet):


### PR DESCRIPTION
Had to fix import of `python_2_unicode_compatible` since it is removed from Django 3.

<https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis>