### PR TITLE
Set up code coverage collection and reporting with codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,33 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+
+source = wagtailmedia
+
+omit =
+    */migrations/*
+
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    return NotImplemented
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,6 @@ script:
   - flake8 wagtailmedia
   - isort --check-only --diff --recursive wagtailmedia
   - tox
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [wagtailmedia](https://pypi.org/project/wagtailmedia/) [![PyPI](https://img.shields.io/pypi/v/wagtailmedia.svg)](https://pypi.org/project/wagtailmedia/)  [![PyPI downloads](https://img.shields.io/pypi/dm/wagtailmedia.svg)](https://pypi.org/project/wagtailmedia/) [![Build Status](https://travis-ci.org/torchbox/wagtailmedia.svg?branch=master)](https://travis-ci.org/torchbox/wagtailmedia)
+# [wagtailmedia](https://pypi.org/project/wagtailmedia/) [![PyPI](https://img.shields.io/pypi/v/wagtailmedia.svg)](https://pypi.org/project/wagtailmedia/)  [![PyPI downloads](https://img.shields.io/pypi/dm/wagtailmedia.svg)](https://pypi.org/project/wagtailmedia/) [![Build Status](https://travis-ci.org/torchbox/wagtailmedia.svg?branch=master)](https://travis-ci.org/torchbox/wagtailmedia) [![Coverage](https://codecov.io/github/torchbox/wagtailmedia/coverage.svg?branch=master)](https://codecov.io/github/torchbox/wagtailmedia?branch=master)
 
 A module for Wagtail that provides functionality similar to `wagtail.documents` module,
 but for audio and video files.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 toxworkdir = /home/vagrant/.tox
 usedevelop = True
 
-envlist = 
+envlist =
     py{35,36,37}-dj{20,21,22}-wag{22,23,24,25,26,27}
     interactive
     flake
@@ -15,7 +15,7 @@ envlist =
 install_command = pip install -e ".[testing]" -U {opts} {packages}
 
 commands =
-    {posargs:python runtests.py}
+    {posargs:coverage run runtests.py}
 
 basepython =
     py35: python3.5
@@ -46,7 +46,7 @@ commands = {posargs:isort --check-only --diff --recursive wagtailmedia}
 
 
 [testenv:interactive]
-commands_pre = 
+commands_pre =
     python {toxinidir}/manage.py makemigrations
     python {toxinidir}/manage.py migrate
     python {toxinidir}/manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('super', 'super@example.com', 'super')"


### PR DESCRIPTION
Following the setup for:

- https://github.com/wagtail/wagtail
- https://github.com/torchbox/wagtail-storages

With the difference that this uses the bash uploader ([recommended by codecov](https://github.com/codecov/example-python#whats-the-different-between-the-codecov-bash-and-codecov-python-uploader)), and uses the GitHub Marketplace app for codecov.