### PR TITLE
Fix interactive demo and tests using the DocumentChooserPanel instead of MediaChooserPanel

### DIFF
--- a/wagtailmedia/tests/testapp/models.py
+++ b/wagtailmedia/tests/testapp/models.py
@@ -4,7 +4,8 @@ from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel
 from wagtail.core.fields import RichTextField
 from wagtail.core.models import Orderable, Page
-from wagtail.documents.edit_handlers import DocumentChooserPanel
+
+from wagtailmedia.edit_handlers import MediaChooserPanel
 
 
 class EventPageRelatedMedia(Orderable):
@@ -24,7 +25,7 @@ class EventPageRelatedMedia(Orderable):
 
     panels = [
         FieldPanel('title'),
-        DocumentChooserPanel('link_media'),
+        MediaChooserPanel('link_media'),
     ]
 
 


### PR DESCRIPTION
This looks like a copy-paste issue when creating the project. It doesn’t seem like there would have been any consequences to this with the unit tests (it’s just the panel that was wrong), but for the new demo setup from #82 is impossible to use as-is.