### PR TITLE
Fixes to support isort version 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
         - pip install tox==3.9.0 flake8 isort
       script:
         - flake8 wagtailmedia
-        - isort --check-only --diff --recursive wagtailmedia
+        - isort --check-only --diff wagtailmedia
         - tox
     - env: TOXENV=py37-dj22-wag26
       python: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands = {posargs:flake8 wagtailmedia}
 
 
 [testenv:isort]
-commands = {posargs:isort --check-only --diff --recursive wagtailmedia}
+commands = {posargs:isort --check-only --diff wagtailmedia}
 
 
 [testenv:interactive]

--- a/wagtailmedia/forms.py
+++ b/wagtailmedia/forms.py
@@ -10,7 +10,8 @@ from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin import widgets
 
 from wagtailmedia.models import Media
-from wagtailmedia.permissions import permission_policy as media_permission_policy
+from wagtailmedia.permissions import \
+    permission_policy as media_permission_policy
 
 if WAGTAIL_VERSION < (2, 5):
     from wagtail.admin.forms import (

--- a/wagtailmedia/models.py
+++ b/wagtailmedia/models.py
@@ -132,8 +132,8 @@ class Media(AbstractMedia):
 
 
 def get_media_model():
-    from django.conf import settings
     from django.apps import apps
+    from django.conf import settings
 
     try:
         app_label, model_name = settings.WAGTAILMEDIA_MEDIA_MODEL.split('.')

--- a/wagtailmedia/permissions.py
+++ b/wagtailmedia/permissions.py
@@ -1,4 +1,6 @@
-from wagtail.core.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.core.permission_policies.collections import (
+    CollectionOwnershipPermissionPolicy
+)
 
 from wagtailmedia.models import Media, get_media_model
 

--- a/wagtailmedia/tests/test_form_override.py
+++ b/wagtailmedia/tests/test_form_override.py
@@ -6,8 +6,12 @@ from django.test import TestCase, override_settings
 from wagtail.admin import widgets
 
 from wagtailmedia import models
-from wagtailmedia.forms import BaseMediaForm, get_media_base_form, get_media_form, media_base_form
-from wagtailmedia.tests.testapp.forms import AlternateMediaForm, OverridenWidget
+from wagtailmedia.forms import (
+    BaseMediaForm, get_media_base_form, get_media_form, media_base_form
+)
+from wagtailmedia.tests.testapp.forms import (
+    AlternateMediaForm, OverridenWidget
+)
 
 
 class TestFormOverride(TestCase):

--- a/wagtailmedia/views/media.py
+++ b/wagtailmedia/views/media.py
@@ -21,7 +21,9 @@ else:
     from wagtail.admin.forms.search import SearchForm
 
 if WAGTAIL_VERSION < (2, 9):
-    from wagtail.admin.utils import PermissionPolicyChecker, permission_denied, popular_tags_for_model
+    from wagtail.admin.utils import (
+        PermissionPolicyChecker, permission_denied, popular_tags_for_model
+    )
 else:
     from wagtail.admin.auth import PermissionPolicyChecker, permission_denied
     from wagtail.admin.models import popular_tags_for_model


### PR DESCRIPTION
isort 5 was released on July 4, 2020, and introduces several breaking changes that prevent tests from succeeding on this repo. See https://timothycrosley.github.io/isort/docs/major_releases/introducing_isort_5/ for details.