### PR TITLE
Fix expected NotImplementedError in Wagtail 1.6+

### DIFF
--- a/wagtailmedia/blocks.py
+++ b/wagtailmedia/blocks.py
@@ -16,5 +16,5 @@ class AbstractMediaChooserBlock(ChooserBlock):
         from wagtailmedia.widgets import AdminMediaChooser
         return AdminMediaChooser
 
-    def render_basic(self, value):
+    def render_basic(self, value, context=None):
         raise NotImplementedError('You need to implement %s.render_basic' % self.__class__.__name__)

--- a/wagtailmedia/tests/test_blocks.py
+++ b/wagtailmedia/tests/test_blocks.py
@@ -1,0 +1,32 @@
+from django.core.files.base import ContentFile
+from django.test import TestCase
+
+from wagtailmedia.blocks import AbstractMediaChooserBlock
+from wagtailmedia.models import Media
+
+
+class BlockTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        fake_file = ContentFile('Test')
+        fake_file.name = 'test.mp3'
+
+        cls.media = Media.objects.create(
+            title='Test',
+            duration=1000,
+            file=fake_file,
+            type='audio'
+        )
+
+    def test_abstract_render_raises_not_implemented_error(self):
+        block = AbstractMediaChooserBlock()
+        with self.assertRaises(NotImplementedError):
+            block.render(self.media)
+
+    def test_render_calls_render_basic(self):
+        class TestMediaChooserBlock(AbstractMediaChooserBlock):
+            def render_basic(self, value, context=None):
+                return value.file.name
+
+        block = TestMediaChooserBlock()
+        self.assertEqual(block.render(self.media), 'media/test.mp3')


### PR DESCRIPTION
The expected behavior when using a custom AbstractMediaChooserBlock without a render_basic is to raise NotImplementedError, but instead you get this error:

`TypeError: render_basic() got an unexpected keyword argument 'context'`

This is because of an outdated signature which [changed in Wagtail 1.6](https://docs.wagtail.io/en/stable/releases/1.6.html#render-and-render-basic-methods-on-streamfield-blocks-now-accept-a-context-keyword-argument).

See Issue #19 and PR #20, which fixed the example in the README but didn't fix the intended functionality.