### PR TITLE
Fix Django3 deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,30 +9,24 @@ cache:
 
 jobs:
   include:
-    - env: TOXENV=py37-dj22-wag27
-      python: 3.7
+    - env: TOXENV=py38-dj30-wag210
+      python: 3.8
       install:
         - pip install tox==3.9.0 flake8 isort
       script:
         - flake8 wagtailmedia
         - isort --check-only --diff wagtailmedia
         - tox
-    - env: TOXENV=py37-dj22-wag26
-      python: 3.7
-    - env: TOXENV=py37-dj22-wag25
-      python: 3.7
-    - env: TOXENV=py36-dj21-wag24
-      python: 3.6
-    - env: TOXENV=py36-dj21-wag23
-      python: 3.6
-    - env: TOXENV=py36-dj20-wag22
-      python: 3.6
-    - env: TOXENV=py35-dj20-wag22
-      python: 3.5
-      # Current Django LTS + current Wagtail LTS, with latest compatible Python.
-      # See https://docs.wagtail.io/en/v2.5.1/releases/upgrading.html
-    - env: TOXENV=py36-dj111-wag23
-      python: 3.6
+    - env: TOXENV=py38-dj22-wag10
+      python: 3.8
+    - env: TOXENV=py38-dj30-wag29
+      python: 3.8
+    - env: TOXENV=py36-dj22-wag28
+      python: 3.8
+      # Current Wagtail LTS, with latest compatible Python.
+      # See https://docs.wagtail.io/en/v2.10/releases/upgrading.html
+    - env: TOXENV=py38-dj22-wag27
+      python: 3.8
 
 install:
   - pip install tox==3.9.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
         - flake8 wagtailmedia
         - isort --check-only --diff wagtailmedia
         - tox
-    - env: TOXENV=py38-dj22-wag10
+    - env: TOXENV=py38-dj22-wag210
       python: 3.8
     - env: TOXENV=py38-dj30-wag29
       python: 3.8
@@ -27,6 +27,12 @@ jobs:
       # See https://docs.wagtail.io/en/v2.10/releases/upgrading.html
     - env: TOXENV=py38-dj22-wag27
       python: 3.8
+    - env: TOXENV=py37-dj22-wag27
+      python: 3.7
+    - env: TOXENV=py36-dj22-wag27
+      python: 3.6
+    - env: TOXENV=py35-dj22-wag27
+      python: 3.5
 
 install:
   - pip install tox==3.9.0

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import os
 import sys

--- a/runtests.py
+++ b/runtests.py
@@ -29,7 +29,7 @@ def runtests():
         warnings.filterwarnings('error', category=RemovedInWagtail27Warning)
         execute_from_command_line(argv)
     finally:
-        from wagtailmedia.tests.settings import STATIC_ROOT, MEDIA_ROOT
+        from wagtailmedia.tests.settings import MEDIA_ROOT, STATIC_ROOT
         shutil.rmtree(STATIC_ROOT, ignore_errors=True)
         shutil.rmtree(MEDIA_ROOT, ignore_errors=True)
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-from wagtailmedia import __version__
-
 import io
 
+from wagtailmedia import __version__
+
 try:
-    from setuptools import setup, find_packages
+    from setuptools import find_packages, setup
 except ImportError:
     from distutils.core import setup
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ testing_extras = [
 
     # Required for matrix build on Travis
     'tox==3.9.0',
-    
+
     # Required for interactive testing via tox
     'psycopg2-binary',
     'django-redis-cache',
@@ -55,15 +55,17 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Django',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Framework :: Wagtail :: 2',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
     install_requires=[
-        'wagtail>=2.2',
+        'wagtail>=2.7',
     ],
     extras_require={
         'testing': testing_extras,

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ toxworkdir = /home/vagrant/.tox
 usedevelop = True
 
 envlist =
-    py{35,36,37,38}-dj{20,21,22}-wag{27,28,29,10}
-    py38-dj30-wag{2.8,2.9,2.10}
+    py{35,36,37,38}-dj{20,21,22}-wag{27,28,29,210}
+    py38-dj30-wag{28,29,210}
     interactive
     flake
     isort

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ toxworkdir = /home/vagrant/.tox
 usedevelop = True
 
 envlist =
-    py{35,36,37}-dj{20,21,22}-wag{22,23,24,25,26,27}
+    py{35,36,37,38}-dj{20,21,22}-wag{27,28,29,10}
+    py38-dj30-wag{2.8,2.9,2.10}
     interactive
     flake
     isort
@@ -21,19 +22,18 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
-    {interactive,flake,isort}: python3.6
+    py38: python3.8
+    {interactive,flake,isort}: python3.8
 
 deps =
-    dj111: Django>=1.11.20,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
-    wag22: wagtail>=2.2,<2.3
-    wag23: wagtail>=2.3,<2.4
-    wag24: wagtail>=2.4,<2.5
-    wag25: wagtail>=2.5,<2.6
-    wag26: wagtail>=2.6,<2.7
+    dj30: Django>=3.0,<3.1
     wag27: wagtail>=2.7,<2.8
+    wag28: wagtail>=2.8,<2.9
+    wag29: wagtail>=2.9,<2.10
+    wag210: wagtail>=2.10,<2.11
     {interactive,flake,isort}: wagtail
 
 

--- a/wagtailmedia/forms.py
+++ b/wagtailmedia/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django.conf import settings
 from django.forms.models import modelform_factory
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin import widgets

--- a/wagtailmedia/models.py
+++ b/wagtailmedia/models.py
@@ -10,7 +10,7 @@ from django.db.models.signals import pre_delete
 from django.dispatch import Signal
 from django.dispatch.dispatcher import receiver
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from taggit.managers import TaggableManager
 from wagtail import VERSION as WAGTAIL_VERSION

--- a/wagtailmedia/tests/settings.py
+++ b/wagtailmedia/tests/settings.py
@@ -1,5 +1,8 @@
 import os
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
+
 DEBUG = 'INTERACTIVE' in os.environ
 
 WAGTAILMEDIA_ROOT = os.path.dirname(__file__)
@@ -76,8 +79,10 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+if WAGTAIL_VERSION < (2, 9):
+    MIDDLEWARE += ['wagtail.core.middleware.SiteMiddleware',]
+
 MIDDLEWARE += [
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 

--- a/wagtailmedia/tests/settings.py
+++ b/wagtailmedia/tests/settings.py
@@ -2,7 +2,6 @@ import os
 
 from wagtail import VERSION as WAGTAIL_VERSION
 
-
 DEBUG = 'INTERACTIVE' in os.environ
 
 WAGTAILMEDIA_ROOT = os.path.dirname(__file__)
@@ -80,7 +79,7 @@ MIDDLEWARE = [
 ]
 
 if WAGTAIL_VERSION < (2, 9):
-    MIDDLEWARE += ['wagtail.core.middleware.SiteMiddleware',]
+    MIDDLEWARE += ['wagtail.core.middleware.SiteMiddleware']
 
 MIDDLEWARE += [
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',

--- a/wagtailmedia/views/media.py
+++ b/wagtailmedia/views/media.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail import VERSION as WAGTAIL_VERSION

--- a/wagtailmedia/wagtail_hooks.py
+++ b/wagtailmedia/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ungettext
 
 from wagtail.admin.menu import MenuItem

--- a/wagtailmedia/widgets.py
+++ b/wagtailmedia/widgets.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import json
 
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.widgets import AdminChooser
 


### PR DESCRIPTION
Fixes #94

* Drops Django 1.11
* Set minimum Wagtail version to 2.7 (current LTS)
* Adds Python 3.8 and Django 3.0 to tox environments