### PR TITLE
Update supported & tested Python, Django, Wagtail versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,24 @@ cache:
 
 jobs:
   include:
-    - env: TOXENV=py38-dj30-wag210
-      python: 3.8
+    - env: TOXENV=py39-dj30-wag210
+      python: 3.9
       install:
         - pip install tox==3.9.0 flake8 isort
       script:
         - flake8 wagtailmedia
         - isort --check-only --diff wagtailmedia
         - tox
-    - env: TOXENV=py38-dj22-wag210
-      python: 3.8
-    - env: TOXENV=py38-dj30-wag29
-      python: 3.8
-    - env: TOXENV=py36-dj22-wag28
-      python: 3.8
+    - env: TOXENV=py39-dj22-wag210
+      python: 3.9
+    - env: TOXENV=py39-dj30-wag29
+      python: 3.9
+    - env: TOXENV=py39-dj22-wag28
+      python: 3.9
       # Current Wagtail LTS, with latest compatible Python.
       # See https://docs.wagtail.io/en/v2.10/releases/upgrading.html
+    - env: TOXENV=py39-dj22-wag27
+      python: 3.9
     - env: TOXENV=py38-dj22-wag27
       python: 3.8
     - env: TOXENV=py37-dj22-wag27

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ jobs:
       python: 3.7
     - env: TOXENV=py36-dj22-wag27
       python: 3.6
-    - env: TOXENV=py35-dj22-wag27
-      python: 3.5
 
 install:
   - pip install tox==3.9.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ cache:
     - .tox
 
 jobs:
+  # See https://docs.wagtail.io/en/latest/releases/upgrading.html
   include:
-    - env: TOXENV=py39-dj30-wag210
+    # Latest Python, latest Django, latest Wagtail.
+    - env: TOXENV=py39-dj31-wag211
       python: 3.9
       install:
         - pip install tox==3.9.0 flake8 isort
@@ -17,14 +19,10 @@ jobs:
         - flake8 wagtailmedia
         - isort --check-only --diff wagtailmedia
         - tox
-    - env: TOXENV=py39-dj22-wag210
+    # Latest Python, latest Django, all other supported Wagtail.
+    - env: TOXENV=py39-dj31-wag210
       python: 3.9
-    - env: TOXENV=py39-dj30-wag29
-      python: 3.9
-    - env: TOXENV=py39-dj22-wag28
-      python: 3.9
-      # Current Wagtail LTS, with latest compatible Python.
-      # See https://docs.wagtail.io/en/v2.10/releases/upgrading.html
+    # All Python versions with Django & Wagtail LTS.
     - env: TOXENV=py39-dj22-wag27
       python: 3.9
     - env: TOXENV=py38-dj22-wag27

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Framework :: Django',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Framework :: Wagtail :: 2',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ toxworkdir = /home/vagrant/.tox
 usedevelop = True
 
 envlist =
-    py{35,36,37,38}-dj{20,21,22}-wag{27,28,29,210}
+    py{36,37,38}-dj{20,21,22}-wag{27,28,29,210}
     py38-dj30-wag{28,29,210}
     interactive
     flake
@@ -19,7 +19,6 @@ commands =
     {posargs:coverage run runtests.py}
 
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ toxworkdir = /home/vagrant/.tox
 usedevelop = True
 
 envlist =
-    py{36,37,38,39}-dj{20,21,22}-wag{27,28,29,210}
-    py38-dj30-wag{28,29,210}
+    py{36,37,38,39}-dj{20,21,22}-wag{27,210,211}
+    py{38,39}-dj{30,31}-wag{210,211}
     interactive
     flake
     isort
@@ -26,14 +26,12 @@ basepython =
     {interactive,flake,isort}: python3.9
 
 deps =
-    dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
     wag27: wagtail>=2.7,<2.8
-    wag28: wagtail>=2.8,<2.9
-    wag29: wagtail>=2.9,<2.10
     wag210: wagtail>=2.10,<2.11
+    wag211: wagtail>=2.11,<2.12
     {interactive,flake,isort}: wagtail
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ toxworkdir = /home/vagrant/.tox
 usedevelop = True
 
 envlist =
-    py{36,37,38}-dj{20,21,22}-wag{27,28,29,210}
+    py{36,37,38,39}-dj{20,21,22}-wag{27,28,29,210}
     py38-dj30-wag{28,29,210}
     interactive
     flake
@@ -22,7 +22,8 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
-    {interactive,flake,isort}: python3.8
+    py39: python3.9
+    {interactive,flake,isort}: python3.9
 
 deps =
     dj20: Django>=2.0,<2.1

--- a/vagrant/README
+++ b/vagrant/README
@@ -12,7 +12,7 @@ To run tests:
         vagrant ssh
 
     then:
-        bash /vagrant/vagrant/runtox.sh -e py36-dj20-wag22
+        bash /vagrant/vagrant/runtox.sh -e py39-dj31-wag211
 
 To run interactive demo inside the vagrant guest:
     ** note: you might need to manually pull the docker images in tox.ini manually on the first run! it hangs for me occasionally **

--- a/vagrant/README
+++ b/vagrant/README
@@ -10,20 +10,20 @@ To run tests:
     cd to this directory on the host machine and issue the following commands:
         vagrant up
         vagrant ssh
-    
+
     then:
-        bash /vagrant/vagrant/runtox.sh -e py35-dj20-wag22
+        bash /vagrant/vagrant/runtox.sh -e py36-dj20-wag22
 
 To run interactive demo inside the vagrant guest:
     ** note: you might need to manually pull the docker images in tox.ini manually on the first run! it hangs for me occasionally **
     docker pull redis:5.0
     docker pull postgres:12.0
-    
+
     bash /vagrant/vagrant/runtox.sh -e interactive
-    
+
     then:
         open your browser on the host and navigate to http://localhost:8020/admin/
-    
+
     log in credentials:
         username: super
         password: super

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -8,7 +8,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
-apt-get install -y python3-distutils build-essential libssl-dev python-dev python3.5 python3.5-dev python3.6 python3.6-dev python3.7 python3.7-dev
+apt-get install -y python3-distutils build-essential libssl-dev python-dev python3.6 python3.6-dev python3.7 python3.7-dev
 
 curl -sSL https://get.docker.com/ | sh
 adduser vagrant docker

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -8,7 +8,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
-apt-get install -y python3-distutils build-essential libssl-dev python-dev python3.6 python3.6-dev python3.7 python3.7-dev
+apt-get install -y python3-distutils build-essential libssl-dev python-dev python3.6 python3.6-dev python3.7 python3.7-dev python3.8 python3.8-dev python3.9 python3.9-dev
 
 curl -sSL https://get.docker.com/ | sh
 adduser vagrant docker


### PR DESCRIPTION
Lots of changes to the package’s peer dependencies:

- Removing Python 3.5
- Adding Python 3.9
- Remove Wagtail 2.8 and 2.9
- Adding Wagtail 2.11
- Adding Django 3.1

All of these are just package metadata & testing matrix changes.