### PR TITLE
Only show MediaSummaryItem for users that can add/manage Media

### DIFF
--- a/wagtailmedia/wagtail_hooks.py
+++ b/wagtailmedia/wagtail_hooks.py
@@ -63,6 +63,11 @@ class MediaSummaryItem(SummaryItem):
             "total_media": get_media_model().objects.count(),
         }
 
+    def is_shown(self):
+        return permission_policy.user_has_any_permission(
+            self.request.user, ["add", "change", "delete"]
+        )
+
 
 @hooks.register("construct_homepage_summary_items")
 def add_media_summary_item(request, items):


### PR DESCRIPTION
Fixes #50

Note, did not add a test for this as Wagtail images/docs summary panels don't have them either