### PR TITLE
Add data-tab-nav attribute to tab nav container

### DIFF
--- a/wagtailmedia/templates/wagtailmedia/chooser/chooser.html
+++ b/wagtailmedia/templates/wagtailmedia/chooser/chooser.html
@@ -6,7 +6,7 @@
 {{ uploadform.media.css }}
 
 {% if uploadform %}
-    <ul class="tab-nav merged">
+    <ul class="tab-nav merged" data-tab-nav>
         <li class="{% if not uploadform.errors %}active{% endif %}"><a href="#search" >{% trans "Search" %}</a></li>
         <li class="{% if uploadform.errors and media_type == 'audio' %}active{% endif %}"><a href="#upload-audio">{% trans "Upload Audio" %}</a></li>
         <li class="{% if uploadform.errors and media_type == 'video' %}active{% endif %}"><a href="#upload-video">{% trans "Upload Video" %}</a></li>


### PR DESCRIPTION
In wagtail 2.13, the `data-tab-nav` attribute is used for selecting tab nav elements, replacing selection by the `tab-nav` class (see https://github.com/wagtail/wagtail/commit/ca0154543aa79b463acf4a58ab45ccd8b8f6bd49). This adds the `data-tab-nav` attribute to the chooser.html template, fixing #129 