### PR TITLE
Add tag filter based on wagtail-images

### DIFF
--- a/wagtailmedia/templates/wagtailmedia/chooser/chooser.html
+++ b/wagtailmedia/templates/wagtailmedia/chooser/chooser.html
@@ -23,6 +23,14 @@
                 {% if collections %}
                     {% include "wagtailadmin/shared/collection_chooser.html" %}
                 {% endif %}
+                {% if popular_tags %}
+                    <li class="taglist">
+                        <h3>{% trans 'Popular tags' %}</h3>
+                        {% for tag in popular_tags %}
+                            <a class="suggested-tag tag" href="{% url 'wagtailmedia:index' %}?tag={{ tag.name|urlencode }}">{{ tag.name }}</a>
+                        {% endfor %}
+                    </li>
+                {% endif %}
             </ul>
         </form>
         <div id="search-results" class="listing media">

--- a/wagtailmedia/templates/wagtailmedia/media/index.html
+++ b/wagtailmedia/templates/wagtailmedia/media/index.html
@@ -1,4 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
+{% load wagtailadmin_tags %}
 {% load i18n %}
 {% block titletag %}Media{% endblock %}
 {% block extra_js %}
@@ -61,6 +62,23 @@
             <form class="image-search search-bar" action="{% url 'wagtailmedia:index' %}" method="GET" novalidate>
                 <ul class="fields">
                     {% include "wagtailadmin/shared/collection_chooser.html" %}
+                    {% if popular_tags %}
+                    <li>
+                        <fieldset class="tagfilter">
+                        <legend>{% trans 'Popular Tags:' %}</legend>
+                          {% for tag in popular_tags %}
+                              {% if tag.name != current_tag %}
+                                  <a class="button button-small button-secondary bicolor button--icon" href="{% url 'wagtailmedia:index' %}{% querystring tag=tag.name %}">{% icon name="tag" wrapped=1 %}{{ tag.name }}</a>
+                              {% else %}
+                                  <a class="button button-small bicolor button--icon" href="{% url 'wagtailmedia:index' %}{% querystring tag=tag.name %}">{% icon name="tag" wrapped=1 %}{{ tag.name }}</a>
+                              {% endif %}
+                          {% endfor %}
+                          {% if current_tag %}
+                              <a class="button button-small bicolor button-secondary button--icon" href="{% url 'wagtailmedia:index' %}{% querystring tag='' %}">{% icon name="cross" wrapped=1 %}{% trans 'Clear choice' %}</a>
+                          {% endif %}
+                        </fieldset>
+                    </li>
+                    {% endif %}
                 </ul>
             </form>
         {% endif %}

--- a/wagtailmedia/views/chooser.py
+++ b/wagtailmedia/views/chooser.py
@@ -62,7 +62,9 @@ def chooser(request):
         uploadform = None
 
     if (
-        "q" in request.GET or "p" in request.GET or "tag" in request.GET
+        "q" in request.GET
+        or "p" in request.GET
+        or "tag" in request.GET
         or "collection_id" in request.GET
     ):
         collection_id = request.GET.get("collection_id")


### PR DESCRIPTION
I basically synced the code with `wagtail.images`:

- `wagtailmedia/templates/wagtailmedia/media/index.html` with https://github.com/wagtail/wagtail/blob/main/wagtail/images/templates/wagtailimages/images/index.html
- `wagtailmedia/views/media.py` with https://github.com/wagtail/wagtail/blob/main/wagtail/images/views/images.py
Here I moved the search-part above the filtering, similar to wagtail-images, which avoided an error during my tests with a wagtail installation.