### PR TITLE
Fix default_auto_field not defined warning

### DIFF
--- a/wagtailmedia/apps.py
+++ b/wagtailmedia/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class WagtailMediaAppConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = "wagtailmedia"
     label = "wagtailmedia"
     verbose_name = "Wagtail media"


### PR DESCRIPTION
Hello, I added `default_auto_field` to apps.py.

Django 3.2 now displays warning if `default_auto_field` is not defined in apps.py or settings.py.

Tested with Django 3.2.5 and 3.0.6