### PR TITLE
File extension validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ INSTALLED_APPS = [
 ]
 ```
 
+All wagtailmedia settings are defined in a single `WAGTAILMEDIA` dictionary in your settings file:
+
+```python
+# settings.py
+
+WAGTAILMEDIA = {
+    "MEDIA_MODEL": "",  # string, dotted-notation. Defaults to "wagtailmedia.Media"
+    "MEDIA_FORM_BASE": "",   # strind, dotted-notation. Defaults to an empty string
+    "AUDIO_EXTENSIONS": [],  # list of extensions
+    "VIDEO_EXTENSIONS": [],  # list of extensions
+}
+```
+
+`AUDIO_EXTENSIONS` defaults to "aac", "aiff", "flac", "m4a", "m4b", "mp3", "ogg" and "wav".
+`VIDEO_EXTENSIONS` defaults to "avi", "h264", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ogv" and "webm".
+
 ### URL configuration
 
 Your project needs to be set up to serve user-uploaded files from `MEDIA_ROOT`.
@@ -51,7 +67,7 @@ With this configuration in place, you are ready to run `./manage.py migrate` to 
 The `Media` model can be customised. To do this, you need
 to add a new model to your project that inherits from `wagtailmedia.models.AbstractMedia`.
 
-Then set the `MEDIA_MODEL` attribute in the `WAGTAILMEDIA` settings to point to it:
+Then set the `MEDIA_MODEL` attribute in the `WAGTAILMEDIA` settings dictionary to point to it:
 
 ```python
 # settings.py
@@ -220,7 +236,6 @@ class BlogPage(Page):
         ('video', VideoChooserBlock(icon='media')),
     ])
 ```
-
 
 ## Translations
 

--- a/README.md
+++ b/README.md
@@ -51,14 +51,27 @@ With this configuration in place, you are ready to run `./manage.py migrate` to 
 The `Media` model can be customised. To do this, you need
 to add a new model to your project that inherits from `wagtailmedia.models.AbstractMedia`.
 
-Then set the `WAGTAILMEDIA_MEDIA_MODEL` setting to point to it:
+Then set the `MEDIA_MODEL` attribute in the `WAGTAILMEDIA` settings to point to it:
 
 ```python
-WAGTAILMEDIA_MEDIA_MODEL = 'mymedia.CustomMedia'
+# settings.py
+WAGTAILMEDIA = {
+    "MEDIA_MODEL": "my_app.CustomMedia",
+    # ...
+}
 ```
 
-You can customize the model form used with your `Media` model using the `WAGTAILMEDIA_MEDIA_FORM_BASE` setting.
+You can customize the model form used with your `Media` model using the `MEDIA_FORM_BASE` setting.
 It should be the dotted path to the form and will be used as the base form passed to `modelform_factory()` when constructing the media form.
+
+```python
+# settings.py
+
+WAGTAILMEDIA = {
+    "MEDIA_FORM_BASE": "my_app.forms.CustomMediaForm",
+    # ...
+}
+```
 
 ### Hooks
 

--- a/src/wagtailmedia/admin.py
+++ b/src/wagtailmedia/admin.py
@@ -1,16 +1,11 @@
-from django.conf import settings
 from django.contrib import admin
 
-from wagtailmedia.models import Media
+from wagtailmedia.settings import wagtailmedia_settings
 
 
-if (
-    hasattr(settings, "WAGTAILMEDIA_MEDIA_MODEL")
-    and settings.WAGTAILMEDIA_MEDIA_MODEL != "wagtailmedia.Media"
-):
-    # This installation provides its own custom media class;
-    # to avoid confusion, we won't expose the unused wagtailmedia.Media class
-    # in the admin.
-    pass
-else:
+if wagtailmedia_settings.MEDIA_MODEL == "wagtailmedia.Media":
+    # Only expose the package-provided media class in the Django admin if the installation
+    # does not provide its own custom media class in order to avoid confusion.
+    from wagtailmedia.models import Media
+
     admin.site.register(Media)

--- a/src/wagtailmedia/deprecation.py
+++ b/src/wagtailmedia/deprecation.py
@@ -1,0 +1,6 @@
+class RemovedInWagtailMedia010Warning(PendingDeprecationWarning):
+    pass
+
+
+class RemovedInWagtailMedia011Warning(DeprecationWarning):
+    pass

--- a/src/wagtailmedia/forms.py
+++ b/src/wagtailmedia/forms.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.conf import settings
 from django.forms.models import modelform_factory
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
@@ -14,6 +13,7 @@ from wagtail.admin.forms.collections import (
 
 from wagtailmedia.models import Media
 from wagtailmedia.permissions import permission_policy as media_permission_policy
+from wagtailmedia.settings import wagtailmedia_settings
 
 
 class BaseMediaForm(BaseCollectionMemberForm):
@@ -37,7 +37,7 @@ class BaseMediaForm(BaseCollectionMemberForm):
 
 
 def get_media_base_form():
-    base_form_override = getattr(settings, "WAGTAILMEDIA_MEDIA_FORM_BASE", "")
+    base_form_override = wagtailmedia_settings.MEDIA_FORM_BASE
     if base_form_override:
         base_form = import_string(base_form_override)
     else:

--- a/src/wagtailmedia/models.py
+++ b/src/wagtailmedia/models.py
@@ -18,6 +18,8 @@ from wagtail.search.queryset import SearchableQuerySetMixin
 
 from taggit.managers import TaggableManager
 
+from wagtailmedia.settings import wagtailmedia_settings
+
 
 ALLOWED_EXTENSIONS_THUMBNAIL = ["gif", "jpg", "jpeg", "png", "webp"]
 
@@ -128,6 +130,13 @@ class AbstractMedia(CollectionMember, index.Indexed, models.Model):
             validate = FileExtensionValidator(ALLOWED_EXTENSIONS_THUMBNAIL)
             validate(self.thumbnail)
 
+        if self.type == "audio" and wagtailmedia_settings.AUDIO_EXTENSIONS:
+            validate = FileExtensionValidator(wagtailmedia_settings.AUDIO_EXTENSIONS)
+            validate(self.file)
+        elif self.type == "video" and wagtailmedia_settings.VIDEO_EXTENSIONS:
+            validate = FileExtensionValidator(wagtailmedia_settings.VIDEO_EXTENSIONS)
+            validate(self.file)
+
     class Meta:
         abstract = True
         verbose_name = _("media")
@@ -166,6 +175,7 @@ def get_media_model():
             "WAGTAILMEDIA[\"MEDIA_MODEL\"] refers to model '%s' that has not been installed"
             % wagtailmedia_settings.MEDIA_MODEL
         )
+
     return media_model
 
 

--- a/src/wagtailmedia/models.py
+++ b/src/wagtailmedia/models.py
@@ -148,22 +148,23 @@ class Media(AbstractMedia):
 
 def get_media_model():
     from django.apps import apps
-    from django.conf import settings
+
+    from wagtailmedia.settings import wagtailmedia_settings
 
     try:
-        app_label, model_name = settings.WAGTAILMEDIA_MEDIA_MODEL.split(".")
+        app_label, model_name = wagtailmedia_settings.MEDIA_MODEL.split(".")
     except AttributeError:
         return Media
     except ValueError:
         raise ImproperlyConfigured(
-            "WAGTAILMEDIA_MEDIA_MODEL must be of the form 'app_label.model_name'"
+            "WAGTAILMEDIA[\"MEDIA_MODEL\"] must be of the form 'app_label.model_name'"
         )
 
     media_model = apps.get_model(app_label, model_name)
     if media_model is None:
         raise ImproperlyConfigured(
-            "WAGTAILMEDIA_MEDIA_MODEL refers to model '%s' that has not been installed"
-            % settings.WAGTAILMEDIA_MEDIA_MODEL
+            "WAGTAILMEDIA[\"MEDIA_MODEL\"] refers to model '%s' that has not been installed"
+            % wagtailmedia_settings.MEDIA_MODEL
         )
     return media_model
 

--- a/src/wagtailmedia/models.py
+++ b/src/wagtailmedia/models.py
@@ -5,7 +5,7 @@ import os.path
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.validators import MinValueValidator
+from django.core.validators import FileExtensionValidator, MinValueValidator
 from django.db import models
 from django.dispatch import Signal
 from django.urls import reverse
@@ -17,6 +17,9 @@ from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 
 from taggit.managers import TaggableManager
+
+
+ALLOWED_EXTENSIONS_THUMBNAIL = ["gif", "jpg", "jpeg", "png", "webp"]
 
 
 class MediaQuerySet(SearchableQuerySetMixin, models.QuerySet):
@@ -120,6 +123,10 @@ class AbstractMedia(CollectionMember, index.Indexed, models.Model):
         super().clean(*args, **kwargs)
         if not self.duration:
             self.duration = 0
+
+        if self.thumbnail:
+            validate = FileExtensionValidator(ALLOWED_EXTENSIONS_THUMBNAIL)
+            validate(self.thumbnail)
 
     class Meta:
         abstract = True

--- a/src/wagtailmedia/settings.py
+++ b/src/wagtailmedia/settings.py
@@ -13,6 +13,8 @@ import warnings
 from django.conf import settings
 from django.test.signals import setting_changed
 
+from wagtailmedia.deprecation import RemovedInWagtailMedia010Warning
+
 
 DEFAULTS = {
     "MEDIA_MODEL": "wagtailmedia.Media",
@@ -34,8 +36,8 @@ DEFAULTS = {
 
 # List of settings that have been deprecated
 DEPRECATED_SETTINGS = [
-    "WAGTAILMEDIA_MEDIA_MODEL",
-    "WAGTAILMEDIA_MEDIA_FORM_BASE",
+    ("WAGTAILMEDIA_MEDIA_MODEL", RemovedInWagtailMedia010Warning),
+    ("WAGTAILMEDIA_MEDIA_FORM_BASE", RemovedInWagtailMedia010Warning),
 ]
 
 # List of settings that have been removed
@@ -85,13 +87,13 @@ class WagtailMediaSettings:
         return val
 
     def __check_user_settings(self, user_settings):
-        for setting in DEPRECATED_SETTINGS:
+        for setting, category in DEPRECATED_SETTINGS:
             if setting in user_settings or hasattr(settings, setting):
                 new_setting = setting.replace("WAGTAILMEDIA_", "")
                 warnings.warn(
                     f"The '{setting}' setting is deprecated and will be removed in the next release, "
                     f'use WAGTAILMEDIA["{new_setting}"] instead.',
-                    category=PendingDeprecationWarning,
+                    category=category,
                 )
                 user_settings[new_setting] = user_settings[setting]
         for setting in REMOVED_SETTINGS:

--- a/src/wagtailmedia/settings.py
+++ b/src/wagtailmedia/settings.py
@@ -14,7 +14,23 @@ from django.conf import settings
 from django.test.signals import setting_changed
 
 
-DEFAULTS = {"MEDIA_MODEL": "wagtailmedia.Media", "MEDIA_FORM_BASE": ""}
+DEFAULTS = {
+    "MEDIA_MODEL": "wagtailmedia.Media",
+    "MEDIA_FORM_BASE": "",
+    "AUDIO_EXTENSIONS": ["aac", "aiff", "flac", "m4a", "m4b", "mp3", "ogg", "wav"],
+    "VIDEO_EXTENSIONS": [
+        "avi",
+        "h264",
+        "m4v",
+        "mkv",
+        "mov",
+        "mp4",
+        "mpeg",
+        "mpg",
+        "ogv",
+        "webm",
+    ],
+}
 
 # List of settings that have been deprecated
 DEPRECATED_SETTINGS = [

--- a/src/wagtailmedia/settings.py
+++ b/src/wagtailmedia/settings.py
@@ -1,0 +1,106 @@
+"""
+The wagtailmedia settings are namespaced in the WAGTAILMEDIA setting.
+For example your project's `settings.py` file might look like this:
+WAGTAILMEDIA = {
+    "MEDIA_MODEL": "mymedia.CustomMedia",
+    # ...
+}
+This module provides the `wagtailmedia_settings` object, that is used to access
+the settings. It checks for user settings first, with fallback to defaults.
+"""
+import warnings
+
+from django.conf import settings
+from django.test.signals import setting_changed
+
+
+DEFAULTS = {"MEDIA_MODEL": "wagtailmedia.Media", "MEDIA_FORM_BASE": ""}
+
+# List of settings that have been deprecated
+DEPRECATED_SETTINGS = [
+    "WAGTAILMEDIA_MEDIA_MODEL",
+    "WAGTAILMEDIA_MEDIA_FORM_BASE",
+]
+
+# List of settings that have been removed
+REMOVED_SETTINGS = []
+
+
+class WagtailMediaSettings:
+    """
+    A settings object that allows the wagtailmedia settings to be accessed as
+    properties. For example:
+        from wagtailmedia.settings import wagtailmedia_settings
+        print(wagtailmedia_settings.MEDIA_MODEL)
+    Note:
+    This is an internal class that is only compatible with settings namespaced
+    under the WAGTAILMEDIA name. It is not intended to be used by 3rd-party
+    apps, and test helpers like `override_settings` may not work as expected.
+    """
+
+    def __init__(self, user_settings=None, defaults=None):
+        if user_settings:
+            self._user_settings = self.__check_user_settings(user_settings)
+        self.defaults = defaults or DEFAULTS
+        self._cached_attrs = set()
+
+    @property
+    def user_settings(self):
+        if not hasattr(self, "_user_settings"):
+            self._user_settings = self.__check_user_settings(
+                getattr(settings, "WAGTAILMEDIA", {})
+            )
+        return self._user_settings
+
+    def __getattr__(self, attr):
+        if attr not in self.defaults:
+            raise AttributeError("Invalid wagtailmedia setting: '%s'" % attr)
+
+        try:
+            # Check if present in user settings
+            val = self.user_settings[attr]
+        except KeyError:
+            # Fall back to defaults
+            val = self.defaults[attr]
+
+        # Cache the result
+        self._cached_attrs.add(attr)
+        setattr(self, attr, val)
+        return val
+
+    def __check_user_settings(self, user_settings):
+        for setting in DEPRECATED_SETTINGS:
+            if setting in user_settings or hasattr(settings, setting):
+                new_setting = setting.replace("WAGTAILMEDIA_", "")
+                warnings.warn(
+                    f"The '{setting}' setting is deprecated and will be removed in the next release, "
+                    f'use WAGTAILMEDIA["{new_setting}"] instead.',
+                    category=PendingDeprecationWarning,
+                )
+                user_settings[new_setting] = user_settings[setting]
+        for setting in REMOVED_SETTINGS:
+            if setting in user_settings:
+                raise RuntimeError(
+                    f"The '{setting}' setting has been removed. "
+                    f"Please refer to the wagtailmedia documentation for available settings."
+                )
+        return user_settings
+
+    def reload(self):
+        for attr in self._cached_attrs:
+            delattr(self, attr)
+        self._cached_attrs.clear()
+        if hasattr(self, "_user_settings"):
+            delattr(self, "_user_settings")
+
+
+wagtailmedia_settings = WagtailMediaSettings(None, DEFAULTS)
+
+
+def reload_wagtailmedia_settings(*args, **kwargs):
+    setting = kwargs["setting"]
+    if setting == "WAGTAILMEDIA":
+        wagtailmedia_settings.reload()
+
+
+setting_changed.connect(reload_wagtailmedia_settings)

--- a/tests/test_form_override.py
+++ b/tests/test_form_override.py
@@ -35,7 +35,7 @@ class TestFormOverride(TestCase):
         self.assertIsInstance(form.fields["thumbnail"].widget, forms.ClearableFileInput)
 
     @override_settings(
-        WAGTAILMEDIA_MEDIA_FORM_BASE="tests.testapp.forms.AlternateMediaForm"
+        WAGTAILMEDIA={"MEDIA_FORM_BASE": "tests.testapp.forms.AlternateMediaForm"}
     )
     def test_overridden_base_form(self):
         self.assertIs(get_media_base_form(), AlternateMediaForm)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -284,3 +284,28 @@ class TestMediaFilesDeletionForCustomModels(TestMediaFilesDeletion):
             "%s.%s" % (cls._meta.app_label, cls.__name__),
             "wagtailmedia_tests.CustomMedia",
         )
+
+
+class TestMediaValidateExtensions(TestCase):
+    def test_create_with_invalid_thumbnail_extension(self):
+        """Checks if created media has an expected extension"""
+        media = Media.objects.create(
+            title="Test media", file="test.mp3", type="audio", thumbnail="thumb.doc"
+        )
+
+        with self.assertRaises(ValidationError):
+            media.full_clean()
+
+        media.delete()
+
+    def test_create_with_valid_thumbnail_extension(self):
+        """Checks if the uploaded media has the expected thumnail extensions."""
+        media = Media.objects.create(
+            title="Test media", file="test.mp3", type="audio", thumbnail="thumb.png"
+        )
+        try:
+            media.full_clean()
+        except ValidationError:
+            self.fail("Validation error is raised even when valid file name is passed")
+
+        media.delete()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -276,7 +276,7 @@ class TestMediaFilesDeletion(TransactionTestCase):
         self.assertFalse(media.file.storage.exists(filename))
 
 
-@override_settings(WAGTAILMEDIA_MEDIA_MODEL="wagtailmedia_tests.CustomMedia")
+@override_settings(WAGTAILMEDIA={"MEDIA_MODEL": "wagtailmedia_tests.CustomMedia"})
 class TestMediaFilesDeletionForCustomModels(TestMediaFilesDeletion):
     def test_media_model(self):
         cls = get_media_model()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,7 @@
 from django.test import TestCase, override_settings
 
+import mock
+
 from wagtailmedia.settings import WagtailMediaSettings, wagtailmedia_settings
 
 
@@ -34,3 +36,12 @@ class SettingsTests(TestCase):
         )
         with self.assertWarnsMessage(PendingDeprecationWarning, msg):
             WagtailMediaSettings({"WAGTAILMEDIA_MEDIA_MODEL": "myapp.CustomMedia"})
+
+    @mock.patch("wagtailmedia.settings.REMOVED_SETTINGS", ["A_REMOVED_SETTING"])
+    def test_runtimeerror_raised_on_removed_setting(self):
+        msg = (
+            "The 'A_REMOVED_SETTING' setting has been removed. "
+            "Please refer to the wagtailmedia documentation for available settings."
+        )
+        with self.assertRaisesMessage(RuntimeError, msg):
+            WagtailMediaSettings({"A_REMOVED_SETTING": "myapp.CustomMedia"})

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,36 @@
+from django.test import TestCase, override_settings
+
+from wagtailmedia.settings import WagtailMediaSettings, wagtailmedia_settings
+
+
+class SettingsTests(TestCase):
+    def test_compatibility_with_override_settings(self):
+        self.assertEqual(
+            wagtailmedia_settings.MEDIA_MODEL,
+            "wagtailmedia.Media",
+            "Checking a known default",
+        )
+
+        with override_settings(WAGTAILMEDIA={"MEDIA_MODEL": "myapp.CustomMedia"}):
+            self.assertEqual(
+                wagtailmedia_settings.MEDIA_MODEL,
+                "myapp.CustomMedia",
+                "Setting should have been updated",
+            )
+
+        self.assertEqual(
+            wagtailmedia_settings.MEDIA_MODEL,
+            "wagtailmedia.Media",
+            "Setting should have been restored",
+        )
+
+    def test_warning_raised_on_deprecated_setting(self):
+        """
+        Make sure user is alerted with an deprecated setting is used.
+        """
+        msg = (
+            "The 'WAGTAILMEDIA_MEDIA_MODEL' setting is deprecated and will be removed in the next release, "
+            'use WAGTAILMEDIA["MEDIA_MODEL"] instead.'
+        )
+        with self.assertWarnsMessage(PendingDeprecationWarning, msg):
+            WagtailMediaSettings({"WAGTAILMEDIA_MEDIA_MODEL": "myapp.CustomMedia"})

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -329,7 +329,7 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
         self.assertEqual(media.collection, evil_plans_collection)
         self.assertEqual(media.type, "video")
 
-    @override_settings(WAGTAILMEDIA_MEDIA_MODEL="wagtailmedia_tests.CustomMedia")
+    @override_settings(WAGTAILMEDIA={"MEDIA_MODEL": "wagtailmedia_tests.CustomMedia"})
     def test_get_with_custom_model(self):
         # both audio and video use the same template
         response = self.client.get(reverse("wagtailmedia:add", args=("video",)))
@@ -516,7 +516,7 @@ class TestMediaEditView(TestCase, WagtailTestUtils):
 
         self.assertContains(response, "File not found")
 
-    @override_settings(WAGTAILMEDIA_MEDIA_MODEL="wagtailmedia_tests.CustomMedia")
+    @override_settings(WAGTAILMEDIA={"MEDIA_MODEL": "wagtailmedia_tests.CustomMedia"})
     def test_get_with_custom_model(self):
         # Build a fake file
         fake_file = ContentFile(b("A boring example song"))
@@ -691,7 +691,7 @@ class TestMediaChooserView(TestCase, WagtailTestUtils):
         self.assertEqual(len(response.context["media_files"]), 1)
         self.assertEqual(response.context["media_files"][0], media)
 
-    @override_settings(WAGTAILMEDIA_MEDIA_MODEL="wagtailmedia_tests.CustomMedia")
+    @override_settings(WAGTAILMEDIA={"MEDIA_MODEL": "wagtailmedia_tests.CustomMedia"})
     def test_with_custom_model(self):
         response = self.client.get(reverse("wagtailmedia:chooser"))
         self.assertEqual(response.status_code, 200)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -47,8 +47,7 @@ class TestMediaIndexView(TestCase, WagtailTestUtils):
 
     @staticmethod
     def make_media():
-        fake_file = ContentFile(b("A boring example song"))
-        fake_file.name = "song.mp3"
+        fake_file = ContentFile(b("A boring example song"), name="song.mp3")
 
         for i in range(50):
             media = models.Media(
@@ -224,8 +223,7 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
 
     def test_post_audio(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example song"))
-        fake_file.name = "song.mp3"
+        fake_file = ContentFile(b("A boring example song"), name="song.mp3")
 
         # Submit
         post_data = {"title": "Test media", "file": fake_file, "duration": 100}
@@ -246,8 +244,7 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
 
     def test_post_video(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example movie"))
-        fake_file.name = "movie.mp4"
+        fake_file = ContentFile(b("A boring example movie"), name="movie.mp4")
 
         # Submit
         post_data = {
@@ -276,8 +273,7 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
         evil_plans_collection = root_collection.add_child(name="Evil plans")
 
         # Build a fake file
-        fake_file = ContentFile(b("A boring example song"))
-        fake_file.name = "song.mp3"
+        fake_file = ContentFile(b("A boring example song"), name="song.mp3")
 
         # Submit
         post_data = {
@@ -304,14 +300,10 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
         root_collection = Collection.get_first_root_node()
         evil_plans_collection = root_collection.add_child(name="Evil plans")
 
-        # Build a fake file
-        fake_file = ContentFile(b("A boring example movie"))
-        fake_file.name = "movie.mp3"
-
         # Submit
         post_data = {
             "title": "Test media",
-            "file": fake_file,
+            "file": ContentFile(b("A boring example movie"), name="movie.mp4"),
             "duration": 100,
             "collection": evil_plans_collection.id,
         }
@@ -406,8 +398,7 @@ class TestMediaAddViewWithLimitedCollectionPermissions(TestCase, WagtailTestUtil
 
     def test_post_audio(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example song"))
-        fake_file.name = "song.mp3"
+        fake_file = ContentFile(b("A boring example song"), name="song.mp3")
 
         # Submit
         post_data = {"title": "Test media", "file": fake_file, "duration": 100}
@@ -428,8 +419,7 @@ class TestMediaAddViewWithLimitedCollectionPermissions(TestCase, WagtailTestUtil
 
     def test_post_video(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example movie"))
-        fake_file.name = "movie.mp4"
+        fake_file = ContentFile(b("A boring example movie"), name="movie.mp4")
 
         # Submit
         post_data = {"title": "Test media", "file": fake_file, "duration": 100}
@@ -454,8 +444,7 @@ class TestMediaEditView(TestCase, WagtailTestUtils):
         self.login()
 
         # Build a fake file
-        fake_file = ContentFile(b("A boring example song"))
-        fake_file.name = "song.mp3"
+        fake_file = ContentFile(b("A boring example song"), name="song.mp3")
 
         # Create a media to edit
         self.media = models.get_media_model().objects.create(
@@ -482,8 +471,7 @@ class TestMediaEditView(TestCase, WagtailTestUtils):
 
     def test_post(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example song"))
-        fake_file.name = "song.mp3"
+        fake_file = ContentFile(b("A boring example song"), name="song.mp3")
 
         # Submit title change
         post_data = {"title": "Test media changed!", "file": fake_file, "duration": 100}
@@ -501,8 +489,7 @@ class TestMediaEditView(TestCase, WagtailTestUtils):
 
     def test_with_missing_source_file(self):
         # Build a fake file
-        fake_file = ContentFile(b("An ephemeral media"))
-        fake_file.name = "to-be-deleted.mp3"
+        fake_file = ContentFile(b("An ephemeral media"), name="to-be-deleted.mp3")
 
         # Create a new media to delete the source for
         media = models.Media.objects.create(
@@ -519,8 +506,7 @@ class TestMediaEditView(TestCase, WagtailTestUtils):
     @override_settings(WAGTAILMEDIA={"MEDIA_MODEL": "wagtailmedia_tests.CustomMedia"})
     def test_get_with_custom_model(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example song"))
-        fake_file.name = "song.mp3"
+        fake_file = ContentFile(b("A boring example song"), name="song.mp3")
 
         # Create a media to edit
         media = models.get_media_model().objects.create(
@@ -603,8 +589,7 @@ class TestMediaChooserView(TestCase, WagtailTestUtils):
 
     @staticmethod
     def make_media():
-        fake_file = ContentFile(b("A boring example song"))
-        fake_file.name = "song.mp3"
+        fake_file = ContentFile(b("A boring example song"), name="song.mp3")
 
         for i in range(50):
             media = models.Media(
@@ -794,8 +779,7 @@ class TestMediaChooserViewPermissions(TestCase, WagtailTestUtils):
         )
         user.groups.add(conspirators_group)
 
-        fake_file = ContentFile(b("A boring song"))
-        fake_file.name = "test-song.mp3"
+        fake_file = ContentFile(b("A boring song"), name="test-song.mp3")
         media = models.Media(
             title="Test",
             duration=100,
@@ -847,7 +831,9 @@ class TestMediaChooserChosenView(TestCase, WagtailTestUtils):
         self.login()
 
         # Create a media to choose
-        self.media = models.Media.objects.create(title="Test media", duration=100)
+        self.media = models.Media.objects.create(
+            title="Test media", file="media.mp3", duration=100
+        )
 
     def test_simple(self):
         response = self.client.get(
@@ -877,7 +863,9 @@ class TestMediaChooserUploadView(TestCase, WagtailTestUtils):
             reverse("wagtailmedia:chooser_upload", args=("audio",)),
             {
                 "media-chooser-upload-title": "Test audio",
-                "media-chooser-upload-file": ContentFile(b("A boring example")),
+                "media-chooser-upload-file": ContentFile(
+                    b("A boring example"), name="audio.mp3"
+                ),
                 "media-chooser-upload-duration": "100",
             },
         )
@@ -899,7 +887,9 @@ class TestMediaChooserUploadView(TestCase, WagtailTestUtils):
             reverse("wagtailmedia:chooser_upload", args=("video",)),
             {
                 "media-chooser-upload-title": "Test video",
-                "media-chooser-upload-file": ContentFile(b("A boring example")),
+                "media-chooser-upload-file": ContentFile(
+                    b("A boring example"), name="video.avi"
+                ),
                 "media-chooser-upload-duration": "100",
                 "media-chooser-upload-width": "640",
                 "media-chooser-upload-height": "480",
@@ -967,7 +957,9 @@ class TestMediaChooserUploadView(TestCase, WagtailTestUtils):
             reverse("wagtailmedia:chooser_upload", args=("video",)),
             {
                 "media-chooser-upload-title": "Test video",
-                "media-chooser-upload-file": ContentFile(b("A boring example")),
+                "media-chooser-upload-file": ContentFile(
+                    b("A boring example"), name="video.avi"
+                ),
                 "media-chooser-upload-duration": "100",
             },
         )


### PR DESCRIPTION
This PR fixes #112:

* adds thumnail extension validation (gif, png, jpg/jpeg, webp)
* moves settings to single namespaced setting (`WAGTAILMEDIA`)
* makes the audio/video extensions configurable, as well as provides (hpoefully) sensible defaults.