### PR TITLE
Fix tests for 2.15rc1

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
     "wagtail.documents",
     "wagtail.admin",
     "wagtail.core",
+    "wagtail.search",
 ]
 
 


### PR DESCRIPTION
wagtail.search is missing from INSTALLED_APPS in the test settings file, which fails in 2.15rc1 as the new default search backend has its own models.

(This error will probably go away if we go ahead with https://github.com/wagtail/wagtail/issues/7633 and change the default back to wagtail.search.backends.db, but having this in INSTALLED_APPS is probably a good thing either way)