### PR TITLE
Tidy up tox targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         experimental: [false]
         include:
           - python-version: "3.10"
-            wagtail: ["2.14", "2.15"]
+            wagtail: ["2.15"]
           - python-version: "3.x"
             toxenv: "wagtailmain"
             experimental: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,6 @@ on:
   push:
   pull_request:
 
-# Current configuration:
-# - django 2.2, python 3.6, wagtail 2.11
-# - django 3.1, python 3.7, wagtail 2.12
-# - django 3.2, python 3.8, wagtail 2.13
-# - django 3.2, python 3.9, wagtail 2.13
-# - django 3.2, python 3.9, wagtail main (allow failures)
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -21,7 +15,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.8"
-      - uses: pre-commit/action@v2.0.2
+      - uses: pre-commit/action@v2.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   test:
@@ -34,6 +28,8 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
         experimental: [false]
         include:
+          - python-version: "3.10"
+            wagtail: ["2.14", "2.15"]
           - python-version: "3.x"
             toxenv: "wagtailmain"
             experimental: true

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ usedevelop = True
 envlist =
     py{37,38,39}-dj{22,31}-wagtail{211,213}
     py{37,38,39}-dj31-wagtail214
-    py{37,38,39,310}-dj{32}-wagtail{214,215}
+    py{37,38,39}-dj{32}-wagtail{214,215}
+    py{310}-dj{32}-wagtail{215}
     interactive
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 usedevelop = True
 
 envlist =
-    py{36,37,38,39}-dj{22,31}-wagtail{211,212,213}
-    py{36,37,38,39}-dj31-wagtail214
-    py{38,39}-dj{32}-wagtail{213,214}
+    py{37,38,39}-dj{22,31}-wagtail{211,213}
+    py{37,38,39}-dj31-wagtail214
+    py{37,38,39,310}-dj{32}-wagtail{214,215}
     interactive
 
 [testenv]
@@ -20,10 +20,9 @@ deps =
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.1,<3.2
     wagtail211: wagtail>=2.11,<2.12
-    wagtail212: wagtail>=2.12,<2.13
-    wagtail213: wagtail>=2.13,<2.14
     wagtail214: wagtail>=2.14,<2.15
-    interactive: wagtail>=2.14,<2.15
+    wagtail215: wagtail>=2.15,<2.16
+    interactive: wagtail>=2.15
 
 install_command = pip install -U {opts} {packages}
 


### PR DESCRIPTION
adds Python 3.10 in the mix, as well as Wagtail 2.15 (we already test against main)