### PR TITLE
Removed module level call to ``get_media_base_form()``

### DIFF
--- a/src/wagtailmedia/forms.py
+++ b/src/wagtailmedia/forms.py
@@ -45,9 +45,6 @@ def get_media_base_form():
     return base_form
 
 
-media_base_form = get_media_base_form()
-
-
 def get_media_form(model):
     fields = model.admin_form_fields
     if "collection" not in fields:
@@ -59,7 +56,7 @@ def get_media_form(model):
 
     return modelform_factory(
         model,
-        form=media_base_form,
+        form=get_media_base_form(),
         fields=fields,
     )
 

--- a/tests/test_form_override.py
+++ b/tests/test_form_override.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from django import forms
 from django.test import TestCase, override_settings
 
@@ -7,18 +5,10 @@ from wagtail.admin import widgets
 
 from tests.testapp.forms import AlternateMediaForm, OverridenWidget
 from wagtailmedia import models
-from wagtailmedia.forms import (
-    BaseMediaForm,
-    get_media_base_form,
-    get_media_form,
-    media_base_form,
-)
+from wagtailmedia.forms import BaseMediaForm, get_media_base_form, get_media_form
 
 
 class TestFormOverride(TestCase):
-    def test_media_base_form(self):
-        self.assertIs(media_base_form, BaseMediaForm)
-
     def test_get_media_base_form(self):
         self.assertIs(get_media_base_form(), BaseMediaForm)
 
@@ -40,13 +30,17 @@ class TestFormOverride(TestCase):
     def test_overridden_base_form(self):
         self.assertIs(get_media_base_form(), AlternateMediaForm)
 
-    @patch("wagtailmedia.forms.media_base_form", AlternateMediaForm)
+    @override_settings(
+        WAGTAILMEDIA={"MEDIA_FORM_BASE": "tests.testapp.forms.AlternateMediaForm"}
+    )
     def test_get_overridden_media_form(self):
         bases = get_media_form(models.Media).__bases__
         self.assertNotIn(BaseMediaForm, bases)
         self.assertIn(AlternateMediaForm, bases)
 
-    @patch("wagtailmedia.forms.media_base_form", AlternateMediaForm)
+    @override_settings(
+        WAGTAILMEDIA={"MEDIA_FORM_BASE": "tests.testapp.forms.AlternateMediaForm"}
+    )
     def test_get_overridden_media_form_widgets(self):
         Form = get_media_form(models.Media)
         form = Form()

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -1,12 +1,13 @@
-from django.forms import ModelForm
 from django.forms.widgets import Widget
+
+from wagtailmedia.forms import BaseMediaForm
 
 
 class OverridenWidget(Widget):
     pass
 
 
-class AlternateMediaForm(ModelForm):
+class AlternateMediaForm(BaseMediaForm):
     class Meta:
         widgets = {
             "tags": OverridenWidget,

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     coverage
     dj22: Django>=2.2,<2.3
     dj31: Django>=3.1,<3.2
-    dj32: Django>=3.1,<3.2
+    dj32: Django>=3.2,<3.3
     wagtail211: wagtail>=2.11,<2.12
     wagtail214: wagtail>=2.14,<2.15
     wagtail215: wagtail>=2.15,<2.16


### PR DESCRIPTION
This caused import issues for projects that subclassed ``BaseMediaForm``.
Updated tests to rely on overriding settings instead of mocking the return value.
Fixed tox config for dj32, which was accidentally only testing Django 3.1.x (the bug was introduced in 5e2f95eb6a).

Fixes #147