### PR TITLE
Update tests to match Wagtail 4.0 markup

### DIFF
--- a/tests/test_edit_handlers.py
+++ b/tests/test_edit_handlers.py
@@ -157,7 +157,14 @@ class MediaChooserPanelTest(TestCase):
         self.assertIn(f'data-chooser-url="{chooser_url}"', result)
         self.assertIn('<span class="title">Test video</span>', result)
         edit_url = reverse("wagtailmedia:edit", args=(self.video.pk,))
-        if WAGTAIL_VERSION >= (2, 17):
+        if WAGTAIL_VERSION >= (4, 0):
+            self.assertIn(
+                f'<a href="{edit_url}" aria-describedby="id_featured_media-title" '
+                f'class="edit-link button button-small button-secondary" '
+                f'target="_blank" rel="noreferrer">Edit this media item</a>',
+                result,
+            )
+        elif WAGTAIL_VERSION >= (2, 17):
             self.assertIn(
                 f'<a href="{edit_url}" class="edit-link button button-small button-secondary" '
                 f'target="_blank" rel="noreferrer">Edit this media item</a>',
@@ -179,7 +186,14 @@ class MediaChooserPanelTest(TestCase):
         self.assertIn(f'data-chooser-url="{chooser_url}"', result)
         self.assertIn('<span class="title">Test video</span>', result)
         edit_url = reverse("wagtailmedia:edit", args=(self.video.pk,))
-        if WAGTAIL_VERSION >= (2, 17):
+        if WAGTAIL_VERSION >= (4, 0):
+            self.assertIn(
+                f'<a href="{edit_url}" aria-describedby="id_featured_media-title" '
+                f'class="edit-link button button-small button-secondary" '
+                f'target="_blank" rel="noreferrer">Edit this video</a>',
+                result,
+            )
+        elif WAGTAIL_VERSION >= (2, 17):
             self.assertIn(
                 f'<a href="{edit_url}" class="edit-link button button-small button-secondary" '
                 f'target="_blank" rel="noreferrer">Edit this video</a>',
@@ -203,7 +217,14 @@ class MediaChooserPanelTest(TestCase):
 
         self.assertIn('<span class="title"></span>', result)
 
-        if WAGTAIL_VERSION >= (2, 17):
+        if WAGTAIL_VERSION >= (4, 0):
+            self.assertIn(
+                '<a href="" aria-describedby="id_featured_media-title" '
+                'class="edit-link button button-small button-secondary w-hidden" target="_blank" '
+                'rel="noreferrer">Edit this media item</a>',
+                result,
+            )
+        elif WAGTAIL_VERSION >= (2, 17):
             self.assertIn(
                 '<a href="" class="edit-link button button-small button-secondary" target="_blank" '
                 'rel="noreferrer">Edit this media item</a>',
@@ -231,7 +252,14 @@ class MediaChooserPanelTest(TestCase):
             media_chooser_panel = self.my_media_chooser_panel.bind_to(
                 instance=self.test_instance, form=form, request=self.request
             )
-        self.assertIn(
-            "<span>This field is required.</span>",
-            media_chooser_panel.render_as_field(),
-        )
+
+        if WAGTAIL_VERSION >= (4, 0):
+            self.assertInHTML(
+                '<p class="error-message">This field is required.</p>',
+                media_chooser_panel.render_as_field(),
+            )
+        else:
+            self.assertIn(
+                "<span>This field is required.</span>",
+                media_chooser_panel.render_as_field(),
+            )

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -6,6 +6,7 @@ from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.urls import reverse
 
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.core.models import Collection, GroupCollectionPermission
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -98,6 +99,11 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
         user.user_permissions.add(admin_permission)
         self.assertTrue(self.client.login(username="changeonly", password="password"))
 
+        if WAGTAIL_VERSION >= (4, 0):
+            self.collection_label_tag = '<label class="w-field__label" for="id_collection" id="id_collection-label">'
+        else:
+            self.collection_label_tag = '<label for="id_collection">'
+
     def test_get_index(self):
         response = self.client.get(reverse("wagtailmedia:index"))
         self.assertEqual(response.status_code, 200)
@@ -127,7 +133,7 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
 
         # media can only be moved to collections you have add permission for,
         # so the 'collection' field is not available here
-        self.assertNotContains(response, '<label for="id_collection">')
+        self.assertNotContains(response, self.collection_label_tag)
 
         # if the user has add permission on a different collection,
         # they should have option to move the media
@@ -141,7 +147,7 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
         )
         response = self.client.get(reverse("wagtailmedia:edit", args=(self.media.id,)))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '<label for="id_collection">')
+        self.assertContains(response, self.collection_label_tag)
         self.assertContains(response, "Nice plans")
         self.assertContains(response, "Evil plans")
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -106,6 +106,11 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()
 
+        if WAGTAIL_VERSION >= (4, 0):
+            self.collection_label_tag = '<label class="w-field__label" for="id_collection" id="id_collection-label">'
+        else:
+            self.collection_label_tag = '<label for="id_collection">'
+
     def test_action_block(self):
         with self.settings(
             TEMPLATES=[
@@ -142,7 +147,7 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
 
         # as standard, only the root collection exists and so no 'Collection' option
         # is displayed on the form
-        self.assertNotContains(response, '<label for="id_collection">')
+        self.assertNotContains(response, self.collection_label_tag)
         self.assertContains(response, "Add audio")
         self.assertNotContains(response, "Add audio or video")
         self.assertContains(
@@ -169,7 +174,7 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
 
         # as standard, only the root collection exists and so no 'Collection' option
         # is displayed on the form
-        self.assertNotContains(response, '<label for="id_collection">')
+        self.assertNotContains(response, self.collection_label_tag)
 
         # draftail should NOT be a standard JS include on this page
         self.assertNotContains(response, "wagtailadmin/js/draftail.js")
@@ -190,7 +195,7 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailmedia/media/add.html")
 
-        self.assertContains(response, '<label for="id_collection">')
+        self.assertContains(response, self.collection_label_tag)
         self.assertContains(response, "Evil plans")
         self.assertContains(response, "Add audio")
         self.assertContains(
@@ -209,7 +214,7 @@ class TestMediaAddView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailmedia/media/add.html")
 
-        self.assertContains(response, '<label for="id_collection">')
+        self.assertContains(response, self.collection_label_tag)
         self.assertContains(response, "Evil plans")
         self.assertContains(response, "Add video")
         self.assertContains(
@@ -361,6 +366,11 @@ class TestMediaAddViewWithLimitedCollectionPermissions(TestCase, WagtailTestUtil
 
         self.client.login(username="moriarty", password="password")
 
+        if WAGTAIL_VERSION >= (4, 0):
+            self.collection_label_tag = '<label class="w-field__label" for="id_collection" id="id_collection-label">'
+        else:
+            self.collection_label_tag = '<label for="id_collection">'
+
     def test_get_audio(self):
         response = self.client.get(reverse("wagtailmedia:add", args=("audio",)))
         self.assertEqual(response.status_code, 200)
@@ -368,7 +378,7 @@ class TestMediaAddViewWithLimitedCollectionPermissions(TestCase, WagtailTestUtil
 
         # user only has access to one collection, so no 'Collection' option
         # is displayed on the form
-        self.assertNotContains(response, '<label for="id_collection">')
+        self.assertNotContains(response, self.collection_label_tag)
         self.assertContains(response, "Add audio")
         self.assertContains(
             response,
@@ -385,7 +395,7 @@ class TestMediaAddViewWithLimitedCollectionPermissions(TestCase, WagtailTestUtil
 
         # user only has access to one collection, so no 'Collection' option
         # is displayed on the form
-        self.assertNotContains(response, '<label for="id_collection">')
+        self.assertNotContains(response, self.collection_label_tag)
         self.assertContains(response, "Add video")
         self.assertContains(
             response,


### PR DESCRIPTION
Fix various test failures on current Wagtail main that are not really breakages, just changes to the HTML returned by Wagtail following the 4.0 redesign.

There are quite a few `RemovedInWagtail50Warning`s being thrown now, but they can probably wait for another time (especially as we might have dropped compatibility with some older versions by the time that comes round, which has a bearing on how we approach them.)