### PR TITLE
Fix dependancy resolution for `MediaChooserPanel` scripts

### DIFF
--- a/src/wagtailmedia/templates/wagtailmedia/chooser/chooser.html
+++ b/src/wagtailmedia/templates/wagtailmedia/chooser/chooser.html
@@ -87,5 +87,3 @@
         {% endif %}
     </div>
 </div>
-
-<script src="{% versioned_static "wagtailmedia/js/tabs.js" %}"></script>

--- a/src/wagtailmedia/widgets.py
+++ b/src/wagtailmedia/widgets.py
@@ -84,6 +84,7 @@ class AdminMediaChooser(AdminChooser):
     def media(self):
         return forms.Media(
             js=[
+                "wagtailmedia/js/tabs.js",
                 "wagtailmedia/js/media-chooser-modal.js",
                 "wagtailmedia/js/media-chooser.js",
             ]


### PR DESCRIPTION
## Issue
[MediaChooserPanel tabs not populating #166](https://github.com/torchbox/wagtailmedia/issues/166)

When using a remote static files storage the additional latency causes the inclusion of the [`static/wagtailmedia/js/tabs.js`](https://github.com/torchbox/wagtailmedia/blob/main/src/wagtailmedia/static/wagtailmedia/js/tabs.js) script within [`templates/wagtailmedia/chooser/chooser.html`](https://github.com/torchbox/wagtailmedia/blob/main/src/wagtailmedia/templates/wagtailmedia/chooser/chooser.html) to be deferred after [`static/wagtailmedia/js/media-chooser-modal.js`](https://github.com/torchbox/wagtailmedia/blob/main/src/wagtailmedia/static/wagtailmedia/js/media-chooser-modal.js) attempts to execute methods of the aforementioned script. This causes a `Uncaught ReferenceError` and prevents the modal from working on first open.

Additionally, [`static/wagtailmedia/js/tabs.js`](https://github.com/torchbox/wagtailmedia/blob/main/src/wagtailmedia/static/wagtailmedia/js/tabs.js) is requested every time the modal is opened.

## Fix

Move [`static/wagtailmedia/js/tabs.js`](https://github.com/torchbox/wagtailmedia/blob/main/src/wagtailmedia/static/wagtailmedia/js/tabs.js) point of inclusion from [`templates/wagtailmedia/chooser/chooser.html`](https://github.com/torchbox/wagtailmedia/blob/main/src/wagtailmedia/templates/wagtailmedia/chooser/chooser.html) to the `AdminMediaChooser.media` within [`wagtailmedia/widgets.py`](https://github.com/torchbox/wagtailmedia/blob/main/src/wagtailmedia/widgets.py)