### PR TITLE
Update UI for Wagtail 4. Fix #173

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ class BlogPage(Page):
     date = models.DateField("Post date")
     body = StreamField(
         [
-            ("heading", blocks.CharBlock(classname="full title", icon="title")),
+            ("heading", blocks.CharBlock(classname="title", icon="title")),
             ("paragraph", blocks.RichTextBlock(icon="pilcrow")),
             ("media", TestMediaBlock(icon="media")),
         ]

--- a/src/wagtailmedia/static/wagtailmedia/js/media-chooser-modal.js
+++ b/src/wagtailmedia/static/wagtailmedia/js/media-chooser-modal.js
@@ -74,7 +74,27 @@ MEDIA_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         $('form.media-upload', modal.body).on('submit', function() {
             var formdata = new FormData(this);
 
-            if ($('#id_title', modal.body).val() == '') {
+            // Get the title field of the submitted form, not the first in the modal.
+            const input = this.querySelector('#id_media-chooser-upload-title');
+            if (!input.value) {
+                if (!input.hasAttribute('aria-invalid')) {
+                    input.setAttribute('aria-invalid', 'true');
+                    const field = input.closest('[data-field]');
+                    field.classList.add('w-field--error');
+                    const errors = field.querySelector('[data-field-errors]');
+                    const icon = errors.querySelector('.icon');
+                    if (icon) {
+                        icon.removeAttribute('hidden');
+                    }
+                    const errorElement = document.createElement('p');
+                    errorElement.classList.add('error-message');
+                    // Global function provided by Wagtail.
+                    errorElement.innerHTML = gettext('This field is required.');
+                    errors.appendChild(errorElement);
+                }
+                setTimeout(cancelSpinner, 500);
+            // Support for WAGTAIL_VERSION < (4, 0, 0)
+            } else if ($('#id_title', modal.body).val() == '') {
                 var li = $('#id_title', modal.body).closest('li');
                 if (!li.hasClass('error')) {
                     li.addClass('error');

--- a/src/wagtailmedia/widgets.py
+++ b/src/wagtailmedia/widgets.py
@@ -60,6 +60,7 @@ class AdminMediaChooser(AdminChooser):
                 "widget": self,
                 "original_field_html": original_field_html,
                 "attrs": attrs,
+                "icon": "media",
                 "value": value_data != {},  # only used to identify blank values
                 "title": value_data.get("title", ""),
                 "edit_url": value_data.get("edit_link", ""),

--- a/tests/testapp/migrations/0002_blogstreampage.py
+++ b/tests/testapp/migrations/0002_blogstreampage.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
                             (
                                 "heading",
                                 wagtail.core.blocks.CharBlock(
-                                    form_classname="full title", icon="title"
+                                    form_classname="title", icon="title"
                                 ),
                             ),
                             (

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -65,8 +65,7 @@ class EventPage(Page):
     signup_link = models.URLField(blank=True)
 
 
-EventPage.content_panels = [
-    FieldPanel("title", classname="full title"),
+EventPage.content_panels = Page.content_panels + [
     FieldPanel("date_from"),
     FieldPanel("date_to"),
     FieldPanel("time_from"),

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -74,7 +74,7 @@ EventPage.content_panels = Page.content_panels + [
     FieldPanel("cost"),
     FieldPanel("signup_link"),
     FieldPanel("body"),
-    InlinePanel("related_media", label="Related media"),
+    InlinePanel("related_media", heading="Related media", label="Media item"),
 ]
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -73,7 +73,7 @@ EventPage.content_panels = Page.content_panels + [
     FieldPanel("location"),
     FieldPanel("cost"),
     FieldPanel("signup_link"),
-    FieldPanel("body", classname="full"),
+    FieldPanel("body"),
     InlinePanel("related_media", label="Related media"),
 ]
 
@@ -117,7 +117,7 @@ class BlogStreamPage(Page):
 
     body = StreamField(
         [
-            ("heading", blocks.CharBlock(classname="full title", icon="title")),
+            ("heading", blocks.CharBlock(classname="title", icon="title")),
             ("paragraph", blocks.RichTextBlock(icon="pilcrow")),
             ("media", TestMediaBlock(icon="media")),
             ("video", VideoChooserBlock(icon="media")),


### PR DESCRIPTION
Fixes #173, and introduces other nice-to-have cleanup and enhancements. This should be backwards-compatible with older Wagtail releases though I only tested with Wagtail 4.0.2.

## Changes to test app and docs

- The `full` classname no longer does anything so can be removed (from test apps and docs only)
- We shouldn’t override the base `Page`’s `title` FieldPanel, as it now sets the placeholder for the field. (test app only)
- With the new UI, it looks much nicer if `InlinePanel` has different text for the field heading and per-item labels (test app only)

## UX improvements

- Adding the `media` icon to the chooser widget makes it look nicer

## Bug fixes

- Applies the error handling bug fix suggested in #173. With existing code retained for compatibility with older releases.

Note I believe there is still a bug _for older releases_ that I’ve left unaddressed. If we look at this code: https://github.com/torchbox/wagtailmedia/blob/d71243a0487465a43b820bd0f4438a3b72b99be8/src/wagtailmedia/static/wagtailmedia/js/media-chooser-modal.js#L77-L82

This applies the error state to the first title field inside the modal even though there are two title fields inside the modal – one for the audio upload, one for video. So uploading a video and forgetting the `title`, the user wouldn’t get our client-side error handling. The fix here would be to replace `modal.body` by `this` within this code, so we target the title field of the currently-submitting form. I don’t have a way to test this and this seems relatively minor so I’ve left the code as-is.

---

Screenshot of the new icon and different text labels in the test app:

![wagtailmedia-icon-labels](https://user-images.githubusercontent.com/877585/193279198-4191ad75-9705-4d73-83b2-a9268233abef.png)
