### PR TITLE
Fix on-delete error when cleaning up thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Now you can run tests as shown below:
 tox
 ```
 
-or, you can run them for a specific environment `tox -e py38-dj32-wagtail213` or specific test
-`tox -e py38-wagtail213 tests.test_views.TestMediaChooserUploadView`
+or, you can run them for a specific environment `tox -e py310-dj41-wagtail40` or specific test
+`tox -e py310-dj41-wagtail40 tests.test_views.TestMediaChooserUploadView`
 
 To run the test app interactively, use `tox -e interactive`, visit `http://127.0.0.1:8020/admin/` and log in with `admin`/`changeme`.

--- a/src/wagtailmedia/models.py
+++ b/src/wagtailmedia/models.py
@@ -100,8 +100,8 @@ class AbstractMedia(CollectionMember, index.Indexed, models.Model):
         return os.path.basename(self.file.name)
 
     @property
-    def thumbnail_filename(self):
-        return os.path.basename(self.thumbnail.name)
+    def thumbnail_filename(self) -> str:
+        return os.path.basename(self.thumbnail.name) if self.thumbnail else ""
 
     @property
     def file_extension(self):

--- a/src/wagtailmedia/signal_handlers.py
+++ b/src/wagtailmedia/signal_handlers.py
@@ -7,7 +7,8 @@ from wagtailmedia.models import get_media_model
 def delete_files(instance):
     # Pass false so FileField doesn't save the model.
     instance.file.delete(False)
-    instance.thumbnail.delete(False)
+    if instance.thumbnail:
+        instance.thumbnail.delete(False)
 
 
 def post_delete_file_cleanup(instance, **kwargs):

--- a/src/wagtailmedia/views/media.py
+++ b/src/wagtailmedia/views/media.py
@@ -119,7 +119,7 @@ def add(request, media_type):
     Media = get_media_model()
     MediaForm = get_media_form(Media)
 
-    if request.POST:
+    if request.method == "POST":
         media = Media(uploaded_by_user=request.user, type=media_type)
         form = MediaForm(request.POST, request.FILES, instance=media, user=request.user)
         if form.is_valid():
@@ -169,7 +169,7 @@ def edit(request, media_id):
     ):
         return permission_denied(request)
 
-    if request.POST:
+    if request.method == "POST":
         original_file = media.file
         form = MediaForm(request.POST, request.FILES, instance=media, user=request.user)
         if form.is_valid():
@@ -246,7 +246,7 @@ def delete(request, media_id):
     ):
         return permission_denied(request)
 
-    if request.POST:
+    if request.method == "POST":
         media.delete()
         messages.success(request, _("Media file '{0}' deleted.").format(media.title))
         return redirect("wagtailmedia:index")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -117,3 +117,4 @@ WAGTAILSEARCH_BACKENDS = {"default": {"BACKEND": "wagtail.search.backends.databa
 ALLOWED_HOSTS = ["*"]
 
 WAGTAIL_SITE_NAME = "Test Site"
+WAGTAILADMIN_BASE_URL = "http://localhost:8020"

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -13,18 +13,18 @@ from wagtailmedia.models import Media
 class BlockTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        fake_file = ContentFile("Test")
-        fake_file.name = "test.mp3"
-
         cls.audio = Media.objects.create(
-            title="Test audio", duration=1000, file=fake_file, type="audio"
+            title="Test audio",
+            duration=1000,
+            file=ContentFile("Test", name="test.mp3"),
+            type="audio",
         )
 
-        fake_file = ContentFile("Test")
-        fake_file.name = "test.mp4"
-
         cls.video = Media.objects.create(
-            title="Test video", duration=1024, file=fake_file, type="video"
+            title="Test video",
+            duration=1024,
+            file=ContentFile("Test", name="test.mp4"),
+            type="video",
         )
 
     def test_abstract_render_raises_not_implemented_error(self):

--- a/tests/test_edit_handlers.py
+++ b/tests/test_edit_handlers.py
@@ -21,18 +21,18 @@ class MediaChooserPanelTest(TestCase):
             AnonymousUser()
         )  # technically, Anonymous users cannot access the admin
 
-        fake_file = ContentFile("Test")
-        fake_file.name = "test.mp3"
-
         cls.audio = Media.objects.create(
-            title="Test audio", duration=1000, file=fake_file, type="audio"
+            title="Test audio",
+            duration=1000,
+            file=ContentFile("Test", name="test.mp3"),
+            type="audio",
         )
 
-        fake_file = ContentFile("Test")
-        fake_file.name = "test.mp4"
-
         cls.video = Media.objects.create(
-            title="Test video", duration=1024, file=fake_file, type="video"
+            title="Test video",
+            duration=1024,
+            file=ContentFile("Test", name="test.mp4"),
+            type="video",
         )
 
         # a MediaChooserPanel class that works on BlogStreamPage's 'video' field

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,11 +17,9 @@ from wagtailmedia.models import Media, get_media_model
 class TestMediaValidation(TestCase):
     def test_duration_validation(self):
         # ensure duration is optional
-        fake_file = ContentFile("A boring example movie")
-        fake_file.name = "movie.mp4"
         media = Media(
             title="Test media file",
-            file=File(fake_file),
+            file=ContentFile("A boring example movie", name="movie.mp4"),
             type="video",
         )
         media.full_clean()
@@ -55,11 +53,9 @@ class TestMediaTemplating(TestCase):
             (1, "1.0"),
             (1234567.7654321, "1234567.7654321"),
         ):
-            fake_file = ContentFile("A boring example movie")
-            fake_file.name = "movie.mp4"
             media = Media(
                 title="Test media file",
-                file=File(fake_file),
+                file=ContentFile("A boring example movie", name="movie.mp4"),
                 type="video",
             )
             media.duration = value
@@ -79,11 +75,9 @@ class TestMediaTemplating(TestCase):
             (1, "1"),
             (1234567.7654321, "1234568"),
         ):
-            fake_file = ContentFile("A boring example movie")
-            fake_file.name = "movie.mp4"
             media = Media(
                 title="Test media file",
-                file=File(fake_file),
+                file=ContentFile("A boring example movie", name="movie.mp4"),
                 type="video",
             )
             media.duration = value
@@ -103,11 +97,9 @@ class TestMediaTemplating(TestCase):
             (1, "1"),
             (1234567.7654321, "1234567.8"),
         ):
-            fake_file = ContentFile("A boring example movie")
-            fake_file.name = "movie.mp4"
             media = Media(
                 title="Test media file",
-                file=File(fake_file),
+                file=ContentFile("A boring example movie", name="movie.mp4"),
                 type="video",
             )
             media.duration = value
@@ -247,7 +239,7 @@ class TestMediaFilesDeletion(TransactionTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # ensure the signal handlers are registred
+        # ensure the signal handlers are registered
         signal_handlers.register_signal_handlers()
 
     def setUp(self):
@@ -264,11 +256,12 @@ class TestMediaFilesDeletion(TransactionTestCase):
 
     def test_media_file_deleted_oncommit(self):
         with transaction.atomic():
-            fake_file = ContentFile("A boring example movie")
-            fake_file.name = "movie-for-deletion.mp4"
-
             media = get_media_model().objects.create(
-                title="", file=File(fake_file), duration=1
+                title="",
+                file=ContentFile(
+                    "A boring example movie", name="movie-for-deletion.mp4"
+                ),
+                duration=1,
             )
             filename = media.file.name
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -62,10 +62,6 @@ class TestMediaPermissions(TestCase):
 
 class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
     def setUp(self):
-        # Build a fake file
-        fake_file = ContentFile("A boring example song")
-        fake_file.name = "song.mp3"
-
         self.root_collection = Collection.get_first_root_node()
         self.evil_plans_collection = self.root_collection.add_child(name="Evil plans")
         self.nice_plans_collection = self.root_collection.add_child(name="Nice plans")
@@ -73,7 +69,7 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
         # Create a media to edit
         self.media = models.Media.objects.create(
             title="Test media",
-            file=fake_file,
+            file=ContentFile("A boring example song", name="song.mp3"),
             collection=self.nice_plans_collection,
             duration=100,
         )


### PR DESCRIPTION
This fixes all cases where the code assumed a thumbnail was present, since thumbnails are actually optional.