### PR TITLE
Changed `SearchField` with `partial_match` to `AutocompleteField`

### DIFF
--- a/src/wagtailmedia/models.py
+++ b/src/wagtailmedia/models.py
@@ -67,12 +67,12 @@ class AbstractMedia(CollectionMember, index.Indexed, models.Model):
     objects = MediaQuerySet.as_manager()
 
     search_fields = CollectionMember.search_fields + [
-        index.SearchField("title", partial_match=True, boost=10),
+        index.AutocompleteField("title", boost=10),
         index.FilterField("title"),
         index.RelatedFields(
             "tags",
             [
-                index.SearchField("name", partial_match=True, boost=10),
+                index.AutocompleteField("name", boost=10),
             ],
         ),
         index.FilterField("uploaded_by_user"),

--- a/src/wagtailmedia/models.py
+++ b/src/wagtailmedia/models.py
@@ -67,11 +67,13 @@ class AbstractMedia(CollectionMember, index.Indexed, models.Model):
     objects = MediaQuerySet.as_manager()
 
     search_fields = CollectionMember.search_fields + [
+        index.SearchField("title", boost=10),
         index.AutocompleteField("title", boost=10),
         index.FilterField("title"),
         index.RelatedFields(
             "tags",
             [
+                index.SearchField("name", boost=10),
                 index.AutocompleteField("name", boost=10),
             ],
         ),


### PR DESCRIPTION
This PR was made to satisfy this issue: https://github.com/torchbox/wagtailmedia/issues/203

Simple PR that changes the `SearchField`s that have `partial_match=True` to use `AutocompleteField` and remove `partial_match`, which is bringing in a `RemovedInWagtail60Warning` when upgrading to `wagtail` 5.0.

Note: This is my first pull request/edit on an open-source repo. Sorry if I've missed anything or done something wrong - I'm open to learning! 😄 