### PR TITLE
Explicitly add in MEDIA_MODEL default to readme config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All wagtailmedia settings are defined in a single `WAGTAILMEDIA` dictionary in y
 # settings.py
 
 WAGTAILMEDIA = {
-    "MEDIA_MODEL": "",  # string, dotted-notation. Defaults to "wagtailmedia.Media"
+    "MEDIA_MODEL": "wagtailmedia.Media",  # string, dotted-notation. Defaults to "wagtailmedia.Media"
     "MEDIA_FORM_BASE": "",  # string, dotted-notation. Defaults to an empty string
     "AUDIO_EXTENSIONS": [],  # list of extensions
     "VIDEO_EXTENSIONS": [],  # list of extensions


### PR DESCRIPTION
Very minor documentation bug that threw us for a bit before we worked it out so putting in tiny PR in case helpful: 

If you paste in the code for `settings.py` from the readme I'd expect it to work without any edits:

```
WAGTAILMEDIA = {
    "MEDIA_MODEL": "",  # string, dotted-notation. Defaults to "wagtailmedia.Media"
    "MEDIA_FORM_BASE": "",  # string, dotted-notation. Defaults to an empty string
    "AUDIO_EXTENSIONS": [],  # list of extensions
    "VIDEO_EXTENSIONS": [],  # list of extensions
}
```

But the MEDIA_MODEL has to be explicitly set to `wagtailmedia.Media` rather than the empty string set in the readme. If you leave as is it throws an error.

Alternatively "" could be treated as None and trigger the default if that's a preffered option to this simpler PR.