### PR TITLE
Updated `insert_editor_css` to `insert_global_admin_css`

### DIFF
--- a/src/wagtailmedia/wagtail_hooks.py
+++ b/src/wagtailmedia/wagtail_hooks.py
@@ -109,7 +109,7 @@ class MediaAdminURLFinder(ModelAdminURLFinder):
 register_admin_url_finder(get_media_model(), MediaAdminURLFinder)
 
 
-@hooks.register("insert_editor_css")
+@hooks.register("insert_global_admin_css")
 def add_media_css_tweaks():
     return format_html(
         '<link rel="stylesheet" href="{}">',


### PR DESCRIPTION
This PR was made to satisfy the issue: https://github.com/torchbox/wagtailmedia/issues/217

Updated the `wagtail_hooks` that contains a hook using `insert_editor_css` which is bringing in a `RemovedInWagtail60Warning` when upgrading to `wagtail` 5.1.
Changing this to use `insert_global_admin_css` will resolve the deprecation warning.