### PR TITLE
Change `classnames` -> `classname` in `wagtail_hooks.py`

### DIFF
--- a/src/wagtailmedia/wagtail_hooks.py
+++ b/src/wagtailmedia/wagtail_hooks.py
@@ -76,7 +76,7 @@ def register_media_search_area():
         _("Media"),
         reverse("wagtailmedia:index"),
         name="media",
-        classnames="icon icon-media",
+        classname="icon icon-media",
         order=400,
     )
 


### PR DESCRIPTION
This PR was made to satisfy the issue: https://github.com/torchbox/wagtailmedia/issues/224

Updated the `wagtail_hooks.py` that contains a hook using the `classnames` attribute which is bringing in a `RemovedInWagtail60Warning` when upgrading to `wagtail` 5.2.

Changing this to use `classname` will resolve the deprecation warning.