### PR TITLE
Wagtail 6.1

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -23,9 +23,9 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Add support for Wagtail 6.1
+- Drop support for Wagtail < 5.2
+- Drop support for Django < 4.2
+
 ## [0.15.1] - 2024-02-5
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -307,6 +307,20 @@ wagtailmedia has translations in French and Chinese. More translations welcome!
 
 All contributions are welcome!
 
+## Upgrading
+
+When upgrading the Wagtail version, it is good practice to also check that the template styles and formatting are up-to-date with the current supported version of Wagtail.
+
+The following templates should be checked:
+
+- `src/wagtailmedia/templates/wagtailmedia/media/add.html`
+- `src/wagtailmedia/templates/wagtailmedia/media/confirm_delete.html`
+- `src/wagtailmedia/templates/wagtailmedia/media/edit.html`
+- `src/wagtailmedia/templates/wagtailmedia/media/index.html`
+- `src/wagtailmedia/templates/wagtailmedia/media/media_chooser.html`
+- `src/wagtailmedia/templates/wagtailmedia/media/media_permissions_formset.html`
+- `src/wagtailmedia/templates/wagtailmedia/media/usage.html`
+
 ### Install
 
 To make changes to this project, first clone this repository:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
 ]
@@ -28,8 +27,8 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
-    "Wagtail>=4.1",
-    "Django>=3.2",
+    "Wagtail>=5.2",
+    "Django>=4.2",
 ]
 
 [project.optional-dependencies]

--- a/src/wagtailmedia/blocks.py
+++ b/src/wagtailmedia/blocks.py
@@ -49,7 +49,7 @@ class AbstractMediaChooserBlock(ChooserBlock):
 
     def render_basic(self, value, context=None):
         raise NotImplementedError(
-            "You need to implement %s.render_basic" % self.__class__.__name__
+            f"You need to implement {self.__class__.__name__}.render_basic"
         )
 
     def get_comparison_class(self) -> Type["MediaChooserBlockComparison"]:

--- a/src/wagtailmedia/models.py
+++ b/src/wagtailmedia/models.py
@@ -176,8 +176,7 @@ def get_media_model():
     media_model = apps.get_model(app_label, model_name)
     if media_model is None:
         raise ImproperlyConfigured(
-            "WAGTAILMEDIA[\"MEDIA_MODEL\"] refers to model '%s' that has not been installed"
-            % wagtailmedia_settings.MEDIA_MODEL
+            f"WAGTAILMEDIA[\"MEDIA_MODEL\"] refers to model '{wagtailmedia_settings.MEDIA_MODEL}' that has not been installed"
         )
 
     return media_model

--- a/src/wagtailmedia/settings.py
+++ b/src/wagtailmedia/settings.py
@@ -68,7 +68,7 @@ class WagtailMediaSettings:
 
     def __getattr__(self, attr):
         if attr not in self.defaults:
-            raise AttributeError("Invalid wagtailmedia setting: '%s'" % attr)
+            raise AttributeError(f"Invalid wagtailmedia setting: '{attr}'")
 
         try:
             # Check if present in user settings

--- a/src/wagtailmedia/templates/wagtailmedia/media/_file_field.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/_file_field.html
@@ -1,7 +1,6 @@
-{% extends "wagtailadmin/shared/field.html" %}
-{% load i18n %}
-{% block form_field %}
-    <a href="{{ media.url }}" class="icon icon-media">{{ media.filename }}</a><br /><br />
+{% load i18n wagtailadmin_tags %}
+{% rawformattedfield field=field %}
+    <a href="{{ media.url }}">{% icon name="media" classname="default" %}{{ media.filename }}</a><br /><br />
     {% trans "Change media file:" %}
     {{ field }}
-{% endblock %}
+{% endrawformattedfield %}

--- a/src/wagtailmedia/templates/wagtailmedia/media/_file_field_as_li.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/_file_field_as_li.html
@@ -1,9 +1,9 @@
 {% load wagtailadmin_tags media_tags %}
 
-{% wagtail_version 6 1 as wagtail61 %}
+{% is_wagtail_version_gte 6 0 as wagtail60 %}
 
 <li class="{% if field.field.required %}required{% endif %} {{ wrapper_classes }} {{ li_classes }} {% if field.errors %}error{% endif %}">
-    {% if wagtail61 %}
+    {% if wagtail60 %}
         {% include "wagtailmedia/media/_file_field.html" %}
     {% else %}
         {% include "wagtailmedia/media/_file_field_legacy.html" %}

--- a/src/wagtailmedia/templates/wagtailmedia/media/_file_field_as_li.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/_file_field_as_li.html
@@ -1,4 +1,11 @@
-{% load wagtailadmin_tags %}
+{% load wagtailadmin_tags media_tags %}
+
+{% wagtail_version 6 1 as wagtail61 %}
+
 <li class="{% if field.field.required %}required{% endif %} {{ wrapper_classes }} {{ li_classes }} {% if field.errors %}error{% endif %}">
-    {% include "wagtailmedia/media/_file_field.html" %}
+    {% if wagtail61 %}
+        {% include "wagtailmedia/media/_file_field.html" %}
+    {% else %}
+        {% include "wagtailmedia/media/_file_field_legacy.html" %}
+    {% endif %}
 </li>

--- a/src/wagtailmedia/templates/wagtailmedia/media/_file_field_legacy.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/_file_field_legacy.html
@@ -1,0 +1,7 @@
+{% extends "wagtailadmin/shared/field.html" %}
+{% load i18n %}
+{% block form_field %}
+    <a href="{{ media.url }}" class="icon icon-media">{{ media.filename }}</a><br /><br />
+    {% trans "Change media file:" %}
+    {{ field }}
+{% endblock %}

--- a/src/wagtailmedia/templates/wagtailmedia/media/_thumbnail_field.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/_thumbnail_field.html
@@ -1,11 +1,10 @@
-{% extends "wagtailadmin/shared/field.html" %}
-{% load i18n %}
-{% block form_field %}
+{% load i18n wagtailadmin_tags %}
+{% rawformattedfield field=field %}
 <div class="w-field__wrapper">
     {% if media.thumbnail %}
-        <a href="{{ media.thumbnail.url }}" class="icon icon-image">{{ media.thumbnail_filename }}</a><br /><br />
+        <a href="{{ media.thumbnail.url }}">{% icon name="image" classname="default" %}{{ media.thumbnail_filename }}</a><br /><br />
     {% endif %}
 
     {{ field }}
 </div>
-{% endblock %}
+{% endrawformattedfield %}

--- a/src/wagtailmedia/templates/wagtailmedia/media/_thumbnail_field_as_li.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/_thumbnail_field_as_li.html
@@ -1,4 +1,11 @@
-{% load wagtailadmin_tags %}
+{% load wagtailadmin_tags media_tags %}
+
+{% wagtail_version 6 1 as wagtail61 %}
+
 <li class="{% if field.field.required %}required{% endif %} {{ wrapper_classes }} {{ li_classes }} {% if field.errors %}error{% endif %}">
-    {% include "wagtailmedia/media/_thumbnail_field.html" %}
+    {% if wagtail61 %}
+        {% include "wagtailmedia/media/_thumbnail_field.html" %}
+    {% else %}
+        {% include "wagtailmedia/media/_thumbnail_field_legacy.html" %}
+    {% endif %}
 </li>

--- a/src/wagtailmedia/templates/wagtailmedia/media/_thumbnail_field_as_li.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/_thumbnail_field_as_li.html
@@ -1,9 +1,9 @@
 {% load wagtailadmin_tags media_tags %}
 
-{% wagtail_version 6 1 as wagtail61 %}
+{% is_wagtail_version_gte 6 0 as wagtail60 %}
 
 <li class="{% if field.field.required %}required{% endif %} {{ wrapper_classes }} {{ li_classes }} {% if field.errors %}error{% endif %}">
-    {% if wagtail61 %}
+    {% if wagtail60 %}
         {% include "wagtailmedia/media/_thumbnail_field.html" %}
     {% else %}
         {% include "wagtailmedia/media/_thumbnail_field_legacy.html" %}

--- a/src/wagtailmedia/templates/wagtailmedia/media/_thumbnail_field_legacy.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/_thumbnail_field_legacy.html
@@ -1,0 +1,11 @@
+{% extends "wagtailadmin/shared/field.html" %}
+{% load i18n %}
+{% block form_field %}
+<div class="w-field__wrapper">
+    {% if media.thumbnail %}
+        <a href="{{ media.thumbnail.url }}" class="icon icon-image">{{ media.thumbnail_filename }}</a><br /><br />
+    {% endif %}
+
+    {{ field }}
+</div>
+{% endblock %}

--- a/src/wagtailmedia/templates/wagtailmedia/media/add.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/add.html
@@ -14,13 +14,8 @@
     {{ block.super }}
     {{ form.media.js }}
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>
         $(function() {
-            $('#id_tags').tagit({
-                autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
-            });
-
             const fileWidget = document.getElementById("id_file");
             const titleWidget = document.getElementById("id_title");
             fileWidget.addEventListener('change', function () {

--- a/src/wagtailmedia/templates/wagtailmedia/media/confirm_delete.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/confirm_delete.html
@@ -7,7 +7,7 @@
 
     <div class="nice-padding">
         <div class="usagecount">
-            <a href="{{ media.usage_url }}">{% blocktrans count usage_count=media.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+            <a href="{{ media.usage_url }}">{% blocktrans trimmed count usage_count=media.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
         </div>
 
         <p>{% trans "Are you sure you want to delete this media file?" %}</p>

--- a/src/wagtailmedia/templates/wagtailmedia/media/edit.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/edit.html
@@ -21,7 +21,7 @@
     {% block form_row %}
         <div class="row row-flush nice-padding">
 
-            {% wagtail_version 6 1 as wagtail61 %}
+            {% is_wagtail_version_gte 6 1 as wagtail61 %}
 
             <div class="col10 {% if not wagtail61 %}divider-after{% endif %}">
                 <form action="{% block action %}{% url 'wagtailmedia:edit' media.pk %}{% endblock %}" method="POST" enctype="multipart/form-data" novalidate>

--- a/src/wagtailmedia/templates/wagtailmedia/media/edit.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load i18n media_tags %}
 {% block titletag %}{% blocktrans with title=media.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
@@ -29,7 +29,9 @@
     {% block form_row %}
         <div class="row row-flush nice-padding">
 
-            <div class="col10 divider-after">
+            {% wagtail_version 6 1 as wagtail61 %}
+
+            <div class="col10 {% if not wagtail61 %}divider-after{% endif %}">
                 <form action="{% block action %}{% url 'wagtailmedia:edit' media.pk %}{% endblock %}" method="POST" enctype="multipart/form-data" novalidate>
                     {% csrf_token %}
                     {% if next %}<input type="hidden" value="{{ next }}" name="next">{% endif %}

--- a/src/wagtailmedia/templates/wagtailmedia/media/edit.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/edit.html
@@ -6,14 +6,6 @@
     {{ block.super }}
     {{ form.media.js }}
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
-    <script>
-        $(function() {
-            $('#id_tags').tagit({
-                autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
-            });
-        });
-    </script>
 {% endblock %}
 
 {% block extra_css %}

--- a/src/wagtailmedia/templates/wagtailmedia/media/index.html
+++ b/src/wagtailmedia/templates/wagtailmedia/media/index.html
@@ -48,22 +48,3 @@
         </div>
     </div>
 {% endblock %}
-
-{% block extra_js %}
-    {{ block.super }}
-    <script>
-        window.headerSearch = {
-            url: "{% url 'wagtailmedia:index' %}",
-            termInput: "#id_q",
-            targetOutput: "#media-results"
-        };
-
-        $(function() {
-            $('#collection_chooser_collection_id').change(function() {
-                const params = new URLSearchParams(window.location.search);
-                this.form["q"].value = params.get("q");
-                this.form.submit();
-            });
-        });
-    </script>
-{% endblock %}

--- a/src/wagtailmedia/templatetags/media_tags.py
+++ b/src/wagtailmedia/templatetags/media_tags.py
@@ -1,0 +1,10 @@
+from django.template import Library
+from wagtail import VERSION as WAGTAIL_VERSION
+
+
+register = Library()
+
+
+@register.simple_tag
+def wagtail_version(*version):
+    return WAGTAIL_VERSION >= version

--- a/src/wagtailmedia/templatetags/media_tags.py
+++ b/src/wagtailmedia/templatetags/media_tags.py
@@ -6,5 +6,5 @@ register = Library()
 
 
 @register.simple_tag
-def wagtail_version(*version):
+def is_wagtail_version_gte(*version):
     return WAGTAIL_VERSION >= version

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,72 @@
+import unittest
+
+from unittest.mock import patch
+
+from django import forms
+from django.http import HttpResponse
+from django.template import Context, Template
+from django.test import TestCase, override_settings
+from django.urls import path
+from django.views import View
+from wagtail import VERSION as WAGTAIL_VERSION
+
+
+class DummyForm(forms.Form):
+    media_file = forms.FileField(label="Change media file:", required=False)
+
+
+class DummyFileFieldView(View):
+    template_string = """
+        {% load media_tags %}
+        {% is_wagtail_version_gte 6 0 as wagtail60 %}  # Update version as needed
+        {% if wagtail60 %}
+            {% include "wagtailmedia/media/_file_field.html" %}
+        {% else %}
+            {% include "wagtailmedia/media/_file_field_legacy.html" %}
+        {% endif %}
+    """
+
+    def get(self, request, *args, **kwargs):
+        template = Template(self.template_string)
+        form = DummyForm()  # Create an instance of the form
+        context_data = self.get_context_data(form=form, **kwargs)
+        return HttpResponse(template.render(Context(context_data)))
+
+    def get_context_data(self, **kwargs):
+        # Mock 'media' and 'field' as they are used in the templates
+        return {
+            "media": {
+                "url": "http://example.com/media/file.mp3",
+                "filename": "file.mp3",
+            },
+            "field": kwargs["form"]["media_file"],  # Passing the actual form field
+            **kwargs,
+        }
+
+
+urlpatterns = [
+    # Temporary URL for testing
+    path(
+        "test-filefield-template/",
+        DummyFileFieldView.as_view(),
+        name="test-filefield-template",
+    ),
+]
+
+
+@override_settings(ROOT_URLCONF=__name__)  # Override ROOT_URLCONF during this test
+class WagtailVersionFileFieldTemplateTests(TestCase):
+    @patch(
+        "wagtailmedia.templatetags.media_tags.WAGTAIL_VERSION", new=(5, 2)
+    )  # Version for legacy template
+    def test_legacy_template_loaded(self):
+        response = self.client.get("/test-filefield-template/")
+        self.assertTemplateUsed(response, "wagtailmedia/media/_file_field_legacy.html")
+
+    @unittest.skipIf(WAGTAIL_VERSION < (6, 0), "Requires Wagtail 6.0 or higher")
+    @patch(
+        "wagtailmedia.templatetags.media_tags.WAGTAIL_VERSION", new=(6, 0)
+    )  # Version for new template
+    def test_new_template_loaded(self):
+        response = self.client.get("/test-filefield-template/")
+        self.assertTemplateUsed(response, "wagtailmedia/media/_file_field.html")

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 min_version = 4.11
 
 env_list =
-    py{38,39,310}-dj{32}-wagtail{41,52}
-    py{311}-dj{41,42}-wagtail{52,60}
-    py{312}-dj{42,50}-wagtail{52,60}
+    py{38,39,310,311}-dj42-wagtail{52,60,61}
+    py{310,311,312}-dj50-wagtail{52,60,61}
 
 base_python =
     py38: python3.8
@@ -38,12 +37,11 @@ setenv =
 
 deps =
     coverage>=7.0,<8.0
-    dj32: Django>=3.2,<3.3
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
-    wagtail41: wagtail>=4.1,<4.2
     wagtail52: wagtail>=5.2,<6.0
-    wagtail60: wagtail>=6.0rc1,<6.1
+    wagtail60: wagtail>=6.0,<6.1
+    wagtail61: wagtail>=6.1,<6.2
 
 install_command = python -Im pip install --upgrade {opts} {packages}
 


### PR DESCRIPTION
# Notes

## Fixes the following

1. Broken file field on Wagtail > 5.2

Starting Wagtail 6.0, the `rawformattedfield` is introduced and replaces direct usage of `wagtailadmin/shared/field.html`

Since `wagtailmedia/media/_file_field.html` is based on `wagtaildocs/documents/_file_field.html`, the former needed to be updated based on the template changes from Wagtail 6.0.

| Without fix, Wagtail 6.1 | With fix, Wagtail 6.1 |
|-------------------------|---------------------|
| ![image](https://github.com/torchbox/wagtailmedia/assets/26372762/d832fe6f-9b21-4e31-8344-b91eaf1647ba) | ![image](https://github.com/torchbox/wagtailmedia/assets/26372762/7f81f063-04b8-4f68-bcb1-ee5cb9caf736) |

A similar fix is applied to `wagtailmedia/media/_thumbnail_file_field.html`

<details>
<summary>Wagtail 6.1 upgrade check list</summary>

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [ ] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [ ] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [ ] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [ ] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [ ] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [ ] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [ ] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [ ] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [ ] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [ ] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [ ] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [ ] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [ ] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [ ] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [ ] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [ ] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [ ] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [ ] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [ ] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [ ] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [ ] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [ ] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [ ] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [ ] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)

</details>