### PR TITLE
Update Tox for Wagtail 6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: 🔒 Harden Runner
@@ -65,6 +65,7 @@ jobs:
           name: coverage-data
           path: .coverage.*
           if-no-files-found: ignore
+          include-hidden-files: true
           retention-days: 1
 
   coverage:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ but for audio and video files.
 
 wagtailmedia requires the following:
 
-- Python (3.8, 3.9, 3.10, 3.11, 3.12)
+- Python (3.9, 3.10, 3.11, 3.12, 3.13)
 - Django (4.2, 5.0, 5.1)
-- Wagtail (5.2, 6.1)
+- Wagtail (5.2, 6.2, 6.3)
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,18 +14,18 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
 ]
 
 dynamic = ["version"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "Wagtail>=5.2",
     "Django>=4.2",

--- a/tox.ini
+++ b/tox.ini
@@ -2,23 +2,24 @@
 min_version = 4.11
 
 env_list =
-    py{38,39,310,311}-dj42-wagtail{52,60,61}
-    py{310,311,312}-dj50-wagtail{52,60,61}
+    py{39,310,311}-dj42-wagtail{52}
+    py{310,311,312}-dj50-wagtail{52,62,63}
+    py{310,311,312,313}-dj51-wagtail63
 
 base_python =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 package = wheel
@@ -39,9 +40,10 @@ deps =
     coverage>=7.0,<8.0
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
+    dj51: Django>=5.1,<5.2
     wagtail52: wagtail>=5.2,<6.0
-    wagtail60: wagtail>=6.0,<6.1
-    wagtail61: wagtail>=6.1,<6.2
+    wagtail62: wagtail>=6.2,<6.3
+    wagtail63: wagtail>=6.3,<6.4
 
 install_command = python -Im pip install --upgrade {opts} {packages}
 


### PR DESCRIPTION
### Update Tox tests for Wagtail 6.3

This PR updates the tox test setup to confirm package is compatible with Wagtail 6.3

Additionally:
- Python 3.8 is dropped due to deprecation and minimum Python version required is updated to 3.9
- Wagtail versions 6.0 and 6.1 are removed from tox tests due to deprecation.
- Django 5.1 and Python 3.13 are added to tox tests as compatible with Wagtail 6.3.