### PR TITLE
Fix tests for background task behaviour in Wagtail 6.4

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,9 +14,10 @@ Media = get_media_model()
 class ApiTestBase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.a_space_odyssey = create_video("2001: A Space Odyssey")
-        cls.tng = create_video("Star Trek: The Next Generation")
-        cls.pink_floyd_time = create_audio("Pink Floyd: Time")
+        with cls.captureOnCommitCallbacks(execute=True):
+            cls.a_space_odyssey = create_video("2001: A Space Odyssey")
+            cls.tng = create_video("Star Trek: The Next Generation")
+            cls.pink_floyd_time = create_audio("Pink Floyd: Time")
 
     def tearDown(self) -> None:
         for item in Media.objects.all():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -111,15 +111,17 @@ class TestMediaTemplating(TestCase):
 class TestMediaQuerySet(TestCase):
     def test_search_method(self):
         # Make a test media
-        media = Media.objects.create(title="Test media file", duration=100)
+        with self.captureOnCommitCallbacks(execute=True):
+            media = Media.objects.create(title="Test media file", duration=100)
 
         # Search for it
         results = Media.objects.search("Test")
         self.assertEqual(list(results), [media])
 
     def test_operators(self):
-        aaa_media = Media.objects.create(title="AAA Test media", duration=100)
-        zzz_media = Media.objects.create(title="ZZZ Test media", duration=100)
+        with self.captureOnCommitCallbacks(execute=True):
+            aaa_media = Media.objects.create(title="AAA Test media", duration=100)
+            zzz_media = Media.objects.create(title="ZZZ Test media", duration=100)
 
         results = Media.objects.search("aaa test", operator="and")
         self.assertEqual(list(results), [aaa_media])
@@ -129,8 +131,9 @@ class TestMediaQuerySet(TestCase):
         self.assertEqual(sorted_results, [aaa_media, zzz_media])
 
     def test_custom_ordering(self):
-        aaa_media = Media.objects.create(title="AAA Test media", duration=100)
-        zzz_media = Media.objects.create(title="ZZZ Test media", duration=100)
+        with self.captureOnCommitCallbacks(execute=True):
+            aaa_media = Media.objects.create(title="AAA Test media", duration=100)
+            zzz_media = Media.objects.create(title="ZZZ Test media", duration=100)
 
         results = Media.objects.order_by("title").search(
             "Test", order_by_relevance=False

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -723,15 +723,16 @@ class TestMediaChooserView(TestCase, WagtailTestUtils):
         self.assertEqual(response.context["media_files"][0], media)
 
     def test_construct_queryset_hook_search(self):
-        media = models.Media.objects.create(
-            title="Test media shown",
-            duration=100,
-            type="audio",
-            uploaded_by_user=self.user,
-        )
-        models.Media.objects.create(
-            title="Test media not shown", duration=100, type="audio"
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            media = models.Media.objects.create(
+                title="Test media shown",
+                duration=100,
+                type="audio",
+                uploaded_by_user=self.user,
+            )
+            models.Media.objects.create(
+                title="Test media not shown", duration=100, type="audio"
+            )
 
         def filter_media(media, request):
             return media.filter(uploaded_by_user=self.user)
@@ -1100,19 +1101,21 @@ class TestUsageCount(TestCase, WagtailTestUtils):
     def test_used_media_usage_count(self):
         media = models.Media.objects.get(id=1)
         page = EventPage.objects.get(id=3)
-        event_page_related_link = EventPageRelatedMedia()
-        event_page_related_link.page = page
-        event_page_related_link.link_media = media
-        event_page_related_link.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            event_page_related_link = EventPageRelatedMedia()
+            event_page_related_link.page = page
+            event_page_related_link.link_media = media
+            event_page_related_link.save()
         self.assertEqual(media.get_usage().count(), 1)
 
     def test_usage_count_appears(self):
         media = models.Media.objects.get(id=1)
         page = EventPage.objects.get(id=3)
-        event_page_related_link = EventPageRelatedMedia()
-        event_page_related_link.page = page
-        event_page_related_link.link_media = media
-        event_page_related_link.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            event_page_related_link = EventPageRelatedMedia()
+            event_page_related_link.page = page
+            event_page_related_link.link_media = media
+            event_page_related_link.save()
         response = self.client.get(reverse("wagtailmedia:edit", args=(1,)))
         self.assertContains(response, "Used 1 time")
 


### PR DESCRIPTION
In Wagtail 6.4 (https://github.com/wagtail/wagtail/pull/12787), updating the search index and reference index after a database update are now handled as background tasks through the django-tasks library. In the default configuration, this happens at the end of the current transaction (if any), and since unit tests are typically wrapped in a transaction, we can no longer count on the results of database updates within tests being immediately visible in search and object usage queries. To ensure that these tasks are executed, we trigger the oncommit hooks via `self.captureOnCommitCallbacks(execute=True)`.