### PR TITLE
Update to support Wagtail 7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-      - 'support/**'
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'support/**'
   pull_request:
     branches: [main]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Support for Wagtail 7.1 ([#262](https://github.com/torchbox/wagtailmedia/pull/262))@damwaingames
+- Support for Wagtail 7.1 ([#262](https://github.com/torchbox/wagtailmedia/pull/262)) @damwaingames
 
 ## [0.16.0] - 2025-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for Wagtail 7.1 ([#262](https://github.com/torchbox/wagtailmedia/pull/262))@damwaingames
+
 ## [0.16.0] - 2025-05-06
 
 ### Added

--- a/src/wagtailmedia/widgets.py
+++ b/src/wagtailmedia/widgets.py
@@ -4,9 +4,15 @@ from django import forms
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
-from wagtail.telepath import register
+
+
+if WAGTAIL_VERSION >= (7, 1):
+    from wagtail.admin.telepath import register
+else:
+    from wagtail.telepath import register
 
 from wagtailmedia.models import get_media_model
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import json
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from wagtail import VERSION as WAGTAIL_VERSION
 
 from wagtailmedia.models import get_media_model
 
@@ -295,9 +296,14 @@ class TestApiMediaListing(ApiTestBase):
         content = json.loads(response.content.decode("UTF-8"))
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            content, {"message": "cannot order by 'random' (unknown field)"}
-        )
+        if WAGTAIL_VERSION >= (7, 1):
+            self.assertEqual(
+                content, {"message": "cannot order by '-random' (unknown field)"}
+            )
+        else:
+            self.assertEqual(
+                content, {"message": "cannot order by 'random' (unknown field)"}
+            )
 
     def test_ordering_by_random_with_offset_gives_error(self):
         response = self.get_response(order="random", offset=10)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -39,7 +39,7 @@ class BlockTests(TestCase):
                 return value.file.name
 
         block = TestMediaChooserBlock()
-        self.assertEqual(block.render(self.audio), "media/test.mp3")
+        self.assertRegex(block.render(self.audio), r"media/test(_\w{7})?.mp3")
 
     def test_media_block_get_form_state(self):
         block = AbstractMediaChooserBlock()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -223,8 +223,8 @@ class TestMediaFilenameProperties(TestCase):
         cls.extensionless_media.save()
 
     def test_filename(self):
-        self.assertEqual("example.mp4", self.media.filename)
-        self.assertEqual("example", self.extensionless_media.filename)
+        self.assertRegex(self.media.filename, r"example(_\w{7})?.mp4")
+        self.assertRegex(self.extensionless_media.filename, r"example(_\w{7})?")
 
     def test_file_extension(self):
         self.assertEqual("mp4", self.media.file_extension)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1038,7 +1038,11 @@ class TestMediaChooserUploadView(TestCase, WagtailTestUtils):
         self.assertEqual(video_form.instance.type, "video")
 
     @override_settings(
-        DEFAULT_FILE_STORAGE="wagtail.test.dummy_external_storage.DummyExternalStorage"
+        STORAGES={
+            "default": {
+                "BACKEND": "wagtail.test.dummy_external_storage.DummyExternalStorage",
+            },
+        }
     )
     def test_upload_with_external_storage(self):
         response = self.client.post(

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ min_version = 4.22
 
 env_list =
     py{3.9,3.10,3.11}-dj42-wagtail{63,70,71}
-    py{3.10,3.11,3.12}-dj51-wagtail{63,70,71}
+    py{3.12}-dj51-wagtail{63,70,71}
     py3.13-dj52-wagtail{70,71}
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.22
 
 env_list =
-    python{3.9,3.10,3.11}-dj42-wagtail{63}
-    python{3.10,3.11,3.12}-dj51-wagtail{63,70}
-    python{3.13}-dj52-wagtail70
+    py{3.9,3.10,3.11}-dj42-wagtail{63,70,71}
+    py{3.10,3.11,3.12}-dj51-wagtail{63,70,71}
+    py3.13-dj52-wagtail{70,71}
 
 [gh-actions]
 python =
@@ -29,8 +29,8 @@ set_env =
     DJANGO_SETTINGS_MODULE = tests.settings
     PYTHONDEVMODE = 1
 
-    python3.12: COVERAGE_CORE=sysmon
-    python3.13: COVERAGE_CORE=sysmon
+    py3.12: COVERAGE_CORE=sysmon
+    py3.13: COVERAGE_CORE=sysmon
 
 extras = testing
 
@@ -40,6 +40,7 @@ deps =
     dj52: Django>=5.2,<5.3
     wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0rc1,<7.1
+    wagtail71: wagtail>=7.1,<7.2
 
 commands_pre =
     python -I {toxinidir}/tests/manage.py migrate

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.22
 
 env_list =
-    py{3.9,3.10,3.11}-dj42-wagtail{63,70,71}
-    py{3.12}-dj51-wagtail{63,70,71}
-    py3.13-dj52-wagtail{70,71}
+    python{3.9,3.10,3.11}-dj42-wagtail{63,70,71}
+    python{3.12}-dj51-wagtail{63,70,71}
+    python{3.13}-dj52-wagtail{70,71}
 
 [gh-actions]
 python =
@@ -29,8 +29,8 @@ set_env =
     DJANGO_SETTINGS_MODULE = tests.settings
     PYTHONDEVMODE = 1
 
-    py3.12: COVERAGE_CORE=sysmon
-    py3.13: COVERAGE_CORE=sysmon
+    python3.12: COVERAGE_CORE=sysmon
+    python3.13: COVERAGE_CORE=sysmon
 
 extras = testing
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
     wagtail63: wagtail>=6.3,<6.4
-    wagtail70: wagtail>=7.0rc1,<7.1
+    wagtail70: wagtail>=7.0,<7.1
     wagtail71: wagtail>=7.1,<7.2
 
 commands_pre =


### PR DESCRIPTION
The changes primarily focus on updating the supported versions of  Wagtail.

## Updates to testing environment and compatibility:
- [tox.ini](https://github.com/torchbox/wagtailmedia/pull/262/commits/0b0d7a804512fb8ff0f6cd38ee823cb90c2924b8):
    - Added testing for Wagtail 7.1 to the matrices
## Updates to imports
- [src/wagtailmedia/widgets.py](https://github.com/torchbox/wagtailmedia/pull/262/commits/8441c379b7aec4486aba70353df2235921bf2c09)
    - Added variable import based upon version to handle moving of telepath in Wagtail 7.1
## Documentation updates:
- [CHANGELOG.md](https://github.com/torchbox/wagtailmedia/pull/262/commits/39200596093bea1edaed88d4d0c3f9cf08de486c): Added an entry for the unreleased changes.
## Other updates:
- Fix tests failing due to change in error message (https://github.com/torchbox/wagtailmedia/pull/262/commits/5463147edaed983935f5aa3a6bef0afcc9b5fc4c)
- Fix test that used removed old style storage backend setting (https://github.com/torchbox/wagtailmedia/pull/262/commits/12e2f5c42d0487b096a63d636a96e805c73dd1ca)
- Fix tests not handling potential duplicate filenames being appended with a uuid (https://github.com/torchbox/wagtailmedia/pull/262/commits/0fe2a05242d37463e3fcde8146d6f429712f60f5)