### PR TITLE
Wagtail 7.2 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_NO_PYTHON_VERSION_WARNING: "1"
   # Keep in sync with .pre-commit-config.yaml/default_language_version/python.
-  PYTHON_LATEST: "3.13"  # because harden runner fails on the 3.13 download
+  PYTHON_LATEST: "3.14"  # because harden runner fails on the 3.14 download
 
 jobs:
   tests:
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: 🔒 Harden Runner

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_schedule: 'quarterly'
 
 default_language_version:
-  python: python3.13
+  python: python3.14
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Support for Wagtail 7.2
+- Support for Python 3.14
+
 ## [0.17.2] - 2025-10-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ but for audio and video files.
 
 wagtailmedia requires the following:
 
-- Python (3.9, 3.10, 3.11, 3.12, 3.13)
+- Python (3.10, 3.11, 3.12, 3.13, 3.14)
 - Django (4.2, 5.1, 5.2)
-- Wagtail (6.3, 6.4, 7.0)
+- Wagtail (6.3, 7.0, 7.2)
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,14 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
 ]
 
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "Wagtail>=6.3",
     "Django>=4.2",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,8 +2,6 @@ import re
 import shutil
 import tempfile
 
-from typing import Optional
-
 from django.core.files.base import ContentFile
 from django.test import TestCase
 
@@ -32,8 +30,8 @@ class TempDirMediaRootMixin(TestCase):
 def create_media(
     media_type: str,
     title: str,
-    duration: Optional[int] = 100,
-    thumbnail: Optional[str] = False,
+    duration: int | None = 100,
+    thumbnail: str | None = False,
 ) -> Media:
     filename = re.sub(r"[/:\"\'] ", "_", title).lower()
     extension = "mp3" if media_type == MediaType.AUDIO else "mp4"

--- a/tox.ini
+++ b/tox.ini
@@ -2,17 +2,17 @@
 min_version = 4.22
 
 env_list =
-    python{3.9,3.10,3.11}-dj42-wagtail{63,70,71}
-    python{3.12}-dj51-wagtail{63,70,71}
-    python{3.13}-dj52-wagtail{70,71}
+    python{3.10,3.12}-dj42-wagtail{63,70,72}
+    python{3.13}-dj{51,52}-wagtail{63,70,72}
+    python{3.14}-dj52-wagtail{70,72}
 
 [gh-actions]
 python =
-    3.9: py3.9
     3.10: py3.10
     3.11: py3.11
     3.12: py3.12
     3.13: py3.13
+    3.14: py3.14
 
 [testenv]
 package = wheel
@@ -31,6 +31,7 @@ set_env =
 
     python3.12: COVERAGE_CORE=sysmon
     python3.13: COVERAGE_CORE=sysmon
+    python3.14: COVERAGE_CORE=sysmon
 
 extras = testing
 
@@ -40,7 +41,7 @@ deps =
     dj52: Django>=5.2,<5.3
     wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0,<7.1
-    wagtail71: wagtail>=7.1,<7.2
+    wagtail72: wagtail>=7.2,<7.3
 
 commands_pre =
     python -I {toxinidir}/tests/manage.py migrate
@@ -48,7 +49,7 @@ commands =
     python -Im coverage run {toxinidir}/tests/manage.py test --deprecation all {posargs: -v 2}
 
 [testenv:coverage-report]
-base_python = python3.13
+base_python = python3.14
 package = skip
 deps =
     coverage>=7.0,<8.0
@@ -58,17 +59,17 @@ commands =
 
 [testenv:wagtailmain]
 description = Test with latest Wagtail main branch
-base_python = python3.13
+base_python = python3.14
 deps =
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 [testenv:interactive]
 package = editable
 description = An interactive environment for local testing purposes
-base_python = python3.13
+base_python = python3.14
 
 deps =
-    wagtail>=6.3,<6.4
+    wagtail>=7.0,<7.1
 
 commands_pre =
     python {toxinidir}/tests/manage.py makemigrations


### PR DESCRIPTION
This pull request updates the project to support Python 3.14 and Wagtail 7.2. It removes support for Python 3.9 and updates documentation, configuration, and testing matrices to reflect these changes.

**Python version updates:**

* Added support for Python 3.14 across all configuration files, removed Python 3.9, and updated the minimum required version to Python 3.10 in `pyproject.toml`, `.pre-commit-config.yaml`, `.github/workflows/test.yml`, and `tox.ini`

**Wagtail version updates:**

* Added support for Wagtail 7.2 in documentation and testing configurations; updated dependency ranges in `tox.ini` and `README.md`
