### PR TITLE
Fix nightly tests, and harden GitHub Actions

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "psycopg2>=2.9"
           pip install "git+https://github.com/wagtail/wagtail.git@main#egg=wagtail"
           pip install -e .[testing]
       - name: Test

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -6,8 +6,7 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions:  {}
 
 jobs:
   nightly-test:
@@ -15,6 +14,8 @@ jobs:
     # See: https://github.com/actions/runner/issues/520
     if: ${{ github.repository == 'torchbox/wagtailmedia' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       postgres:
@@ -26,13 +27,13 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,6 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.14'
-          cache: "pip"
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: ⬇️ Install build dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,13 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   # https://docs.pypi.org/trusted-publishers/using-a-publisher/
   release:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'torchbox' && github.event.action == 'published'
     environment:
       name: 'release'
       url: https://pypi.org/p/wagtailmedia
@@ -32,14 +35,14 @@ jobs:
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: "pip"
           cache-dependency-path: "**/pyproject.toml"
 
@@ -51,4 +54,4 @@ jobs:
         run: python -Im flit build
 
       - name: 🚀 Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -8,15 +8,28 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v5
+    - name: Harden Runner
+      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
+      with:
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          files.pythonhosted.org:443
+          objects.githubusercontent.com:443
+          github.com:443
+          pypi.org:443
+          api.github.com:443
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           # Use latest Python, so it understands all syntax.
           python-version: ${{env.PYTHON_LATEST}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,11 @@ jobs:
             github.com:443
             pypi.org:443
             api.github.com:443
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: 🐍 Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -62,7 +62,7 @@ jobs:
         run: tox --installpkg ./dist/*.whl
 
       - name: ⬆️ Upload coverage data
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-data-${{ matrix.python-version }}
           path: .coverage.*
@@ -85,11 +85,11 @@ jobs:
             github.com:443
             pypi.org:443
             api.github.com:443
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           # Use latest Python, so it understands all syntax.
           python-version: ${{env.PYTHON_LATEST}}
@@ -97,7 +97,7 @@ jobs:
       - run: python -Im pip install --upgrade coverage
 
       - name: Download coverage data
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -110,7 +110,7 @@ jobs:
           echo "## Coverage summary" >> $GITHUB_STEP_SUMMARY
           python -Im coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
       - name: 📈 Upload HTML report if check failed.
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: html-report
           path: htmlcov

--- a/.github/workflows/zizmore.yml
+++ b/.github/workflows/zizmore.yml
@@ -1,0 +1,31 @@
+# https://github.com/woodruffw/zizmor
+name: Zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          persona: pedantic

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Now you can run tests as shown below:
 tox
 ```
 
-or, you can run them for a specific environment `tox -e py313-dj51-wagtail70` or specific test
-`tox -e py313-dj51-wagtail70 -- tests.test_views.TestMediaChooserUploadView`
+or, you can run them for a specific environment `tox -e python3.13-django5.2-wagtail7.0` or specific test
+`tox -e python3.14-django5.2-wagtail7.0 -- tests.test_views.TestMediaChooserUploadView`
 
 To run the test app interactively, use `tox -e interactive`, visit `http://127.0.0.1:8020/admin/` and log in with `admin`/`changeme`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 testing = [
     "coverage>=7.14.0",
     "tox>=4.54.0",
+    "psycopg"
 ]
 linting = [
     "pre-commit>=4.6.0",

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -61,10 +61,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-MIDDLEWARE += [
-    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
-]
-
 INSTALLED_APPS = [
     "testapp",
     "wagtailmedia",
@@ -73,8 +69,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.staticfiles",
-    "wagtail.contrib.redirects",
-    "wagtail.contrib.search_promotions",
+    "django.contrib.postgres",
     "wagtail.images",
     "wagtail.users",
     "wagtail.documents",
@@ -88,9 +83,7 @@ INSTALLED_APPS = [
 # This prevents false-positives in some wagtail core tests where we are
 # changing the 'wagtail_root_paths' key which may cause future tests to fail.
 
-REDIS_PORT = os.getenv("REDIS_6379_TCP_PORT", "")
-
-if REDIS_PORT:
+if REDIS_PORT := os.getenv("REDIS_PORT", ""):
     CACHES = {
         "default": {
             "BACKEND": "redis_cache.RedisCache",
@@ -116,5 +109,5 @@ WAGTAILSEARCH_BACKENDS = {"default": {"BACKEND": "wagtail.search.backends.databa
 # https://github.com/django/django/commit/adb96617897690b3a01e39e8297ae7d67825d2bc
 ALLOWED_HOSTS = ["*"]
 
-WAGTAIL_SITE_NAME = "Test Site"
+WAGTAIL_SITE_NAME = "wagtailmedia Test Site"
 WAGTAILADMIN_BASE_URL = "http://localhost:8020"

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,18 @@
 min_version = 4.30
 
 env_list =
-    python{3.11}-dj52-wagtail70
-    python{3.12}-dj52-wagtail73
-    python{3.13}-dj52-wagtail74
-    python{3.14}-dj{52,60}-wagtail{74}
+    python{3.11}-django5.2-wagtail7.0
+    python{3.12}-django5.2-wagtail7.3
+    python{3.13}-django5.2-wagtail7.4
+    python{3.14}-django{5.2,6.0}-wagtail{7.4}
 
 [gh-actions]
 python =
-    3.10: py3.10
-    3.11: py3.11
-    3.12: py3.12
-    3.13: py3.13
-    3.14: py3.14
+    3.10: python3.10
+    3.11: python3.11
+    3.12: python3.12
+    3.13: python3.13
+    3.14: python3.14
 
 [testenv]
 package = wheel
@@ -37,11 +37,11 @@ set_env =
 extras = testing
 
 deps =
-    dj52: Django>=5.2,<5.3
-    dj60: Django>=6.0,<6.1
-    wagtail70: wagtail>=7.0,<7.1
-    wagtail73: wagtail>=7.3,<7.4
-    wagtail74: wagtail>=7.4,<7.5
+    django5.2: Django>=5.2,<5.3
+    django6.0: Django>=6.0,<6.1
+    wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.3: wagtail>=7.3,<7.4
+    wagtail7.4: wagtail>=7.4,<7.5
 
 commands_pre =
     python -I {toxinidir}/tests/manage.py migrate

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-min_version = 4.22
+min_version = 4.30
 
 env_list =
     python{3.11}-dj52-wagtail70


### PR DESCRIPTION
- Adds the missing `django.contrib.postgres` from the test settings
- Pins GitHub Actions to release hashes